### PR TITLE
Fix NaN produced during some XYZ to Oklab conversions

### DIFF
--- a/src/details/math.rs
+++ b/src/details/math.rs
@@ -48,6 +48,15 @@ impl Vec3 {
         }
     }
 
+    /// Raise each component to 1. / 3.
+    pub fn cbrt(self) -> Self {
+        Self {
+            x: self.x.cbrt(),
+            y: self.y.cbrt(),
+            z: self.z.cbrt(),
+        }
+    }
+
     pub fn cmplt(self, other: Self) -> BVec3 {
         BVec3 {
             x: self.x < other.x,

--- a/src/details/transform.rs
+++ b/src/details/transform.rs
@@ -175,7 +175,9 @@ const OKLAB_M_2: [FType;9] =
 #[inline]
 pub fn XYZ_to_Oklab(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let mut lms = Mat3::from_cols_array(&OKLAB_M_1).transpose() * color;
-    lms = lms.powf(1.0 / 3.0); // non-linearity
+    // [cbrt] raises `lms` to (1. / 3.) but also avoids NaN when a component of `lms` is negative.
+    // `lms` can contain negative numbers in some cases like when `color` is (0.0, 0.0, 1.0)
+    lms = lms.cbrt(); // non-linearity
     Mat3::from_cols_array(&OKLAB_M_2).transpose() * lms
 }
 


### PR DESCRIPTION
I stumbled across this issue today. It seems like a very easy error to make when implementing Oklab and took a bit of time to track down the fix.

Negative numbers can be produced for the `lms` components during conversion. Raising those to `1. / 3.` with `powf` can produce `NaN` values. Using `cbrt` instead avoids that and matches the expected values in the table "Table of example XYZ and Oklab pairs" on this page: https://bottosson.github.io/posts/oklab/