### PR TITLE
std and glam features

### DIFF
--- a/build/kolor-64/Cargo.toml
+++ b/build/kolor-64/Cargo.toml
@@ -21,9 +21,11 @@ num-traits = { version = "^0.2.14", optional = true, default-features = false }
 glam = { version = "0.17.1", default-features = false, optional = true }
 
 [features]
-default = ["color-matrices", "f64", "std", "glam"]
+default = ["color-matrices", "f64", "std-glam"]
 serde1 = ["serde", "glam/serde"]
 color-matrices = []
 f64 = []
-std = ["glam/std"]
-libm = ["num-traits", "num-traits/libm", "glam/libm"]
+std = []
+std-glam = ["std", "glam/std"]
+libm = ["num-traits", "num-traits/libm"]
+libm-glam = ["libm", "glam/libm"]

--- a/build/kolor/Cargo.toml
+++ b/build/kolor/Cargo.toml
@@ -21,9 +21,11 @@ num-traits = { version = "^0.2.14", optional = true, default-features = false }
 glam = { version = "0.17.1", default-features = false, optional = true }
 
 [features]
-default = ["color-matrices", "f32", "std", "glam"]
+default = ["color-matrices", "f32", "std-glam"]
 serde1 = ["serde", "glam/serde"]
 color-matrices = []
 f32 = []
-std = ["glam/std"]
-libm = ["num-traits", "num-traits/libm", "glam/libm"]
+std = []
+std-glam = ["std", "glam/std"]
+libm = ["num-traits", "num-traits/libm"]
+libm-glam = ["libm", "glam/libm"]

--- a/kolor/src/details/math.rs
+++ b/kolor/src/details/math.rs
@@ -113,6 +113,12 @@ mod math {
         pub fn dot(self, other: Self) -> FType {
             self.x * other.x + self.y * other.y + self.z * other.z
         }
+
+        pub fn abs_diff_eq(self, other: Self, max_abs_diff: FType) -> bool {
+            (self.x - other.x).abs() <= max_abs_diff
+                && (self.y - other.y).abs() <= max_abs_diff
+                && (self.z - other.z).abs() <= max_abs_diff
+        }
     }
 
     impl super::Cuberoot for Vec3 {

--- a/kolor/src/details/math.rs
+++ b/kolor/src/details/math.rs
@@ -37,10 +37,12 @@ mod math {
 #[cfg(not(feature = "glam"))]
 mod math {
     use crate::FType;
-    use std::ops::{Add, Div, Mul, MulAssign, Sub};
+    #[cfg(all(not(feature = "std"), feature = "libm"))]
+    use core::ops::{Add, Div, Mul, MulAssign, Sub};
     #[cfg(all(not(feature = "std"), feature = "libm"))]
     use num_traits::Float;
-
+    #[cfg(all(not(feature = "libm"), feature = "std"))]
+    use std::ops::{Add, Div, Mul, MulAssign, Sub};
 
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
     #[derive(Debug, Clone, Copy, PartialEq)]
@@ -113,7 +115,7 @@ mod math {
         }
     }
 
-    impl Cuberoot for Vec3 {
+    impl super::Cuberoot for Vec3 {
         #[inline]
         fn cbrt(&self) -> Self {
             Self::new(self.x.cbrt(), self.y.cbrt(), self.z.cbrt())

--- a/kolor/src/details/transform.rs
+++ b/kolor/src/details/transform.rs
@@ -786,17 +786,27 @@ mod test {
         let inverse_val = crate::details::transform::pq::ST_2084_PQ_eotf_float(pq_val);
         assert!(
             (value - inverse_val).abs() < 0.001,
-            "pq_val {} inverse {}",
+            "pq_val {:?} inverse {:?}",
             value,
             inverse_val
         );
         // validate inverse matrices
         let value = Vec3::new(0.5, 0.5, 0.5);
         let result = ICtCp::ICtCp_From_PQ_INVERSE * (ICtCp::ICtCp_From_PQ * value);
-        assert!(value.abs_diff_eq(result, 0.0001), "{} != {}", value, result);
+        assert!(
+            value.abs_diff_eq(result, 0.0001),
+            "{:?} != {:?}",
+            value,
+            result
+        );
 
         let result = ICtCp::ICtCp_LMS_INVERSE * (ICtCp::ICtCp_LMS * value);
-        assert!(value.abs_diff_eq(result, 0.0001), "{} != {}", value, result);
+        assert!(
+            value.abs_diff_eq(result, 0.0001),
+            "{:?} != {:?}",
+            value,
+            result
+        );
 
         let to = |value: Vec3| from_conv.convert(to_conv.convert(value));
         let from = |value: Vec3| from_conv.convert(to_conv.convert(value));
@@ -806,7 +816,7 @@ mod test {
         let allowed_error = 0.002;
         assert!(
             value.abs_diff_eq(result, allowed_error),
-            "{} != {}",
+            "{:?} != {:?}",
             value,
             result
         );
@@ -815,7 +825,7 @@ mod test {
         let result = from(to(value));
         assert!(
             value.abs_diff_eq(result, allowed_error),
-            "{} != {}",
+            "{:?} != {:?}",
             value,
             result
         );
@@ -824,7 +834,7 @@ mod test {
         let result = from(to(value));
         assert!(
             value.abs_diff_eq(result, allowed_error),
-            "{} != {}",
+            "{:?} != {:?}",
             value,
             result
         );

--- a/kolor/src/lib.rs
+++ b/kolor/src/lib.rs
@@ -95,8 +95,15 @@
 //! Functions in [details::xyz] can be used to create conversion matrices to/from an RGB color space
 //! given a set of primaries and a white point.
 //!
-//! # no_std support
-//! kolor supports `no_std` by disabling the default-enabled `std` feature and enabling the `libm` feature.
+//! # no_std and glam support
+//! kolor is using by default `std` and `glam`, but both can be disabled separately or together with the
+//! folowing features:
+//!
+//! | |`std`|`no_std`|
+//! |-|-|-|
+//! |`glam`|`std-glam`|`libm-glam`|
+//! |no `glam`|`std`|`libm`|
+//!
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/matrix-gen/Cargo.toml
+++ b/matrix-gen/Cargo.toml
@@ -8,6 +8,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 kolor-64 = { version = "0.1.7", path = "../build/kolor-64", default-features = false, features = [
-    "std",
+    "std-glam",
     "f64"
 ] }


### PR DESCRIPTION
fix features so that `glam` can be removed

with those changes, it compiles with or without std, and with or without glam
tests are also running (but failing) on std without glam, they are still not compiling without std as there are quite a few `println!` and I'm not sure what `assert!` could replace them

edit: just noticed this would fix #8 