### PR TITLE
Deps bump, type/API naming, docs fixes, feature flag docs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["matrix-gen", "build/kolor", "build/kolor-64", "examples"]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -1,37 +1,47 @@
-# kolor
+# `kolor`
 
-kolor is a crate for doing conversions between color spaces and helps with some other color math.
+A crate for doing conversions between color spaces that also helps with some
+color math.
 
-kolor is intended for use in games or other interactive visual applications,
-where it can help implement correct color management, wide color gamut rendering and tonemapping.
+`kolor` is intended for use in games or other interactive visual applications,
+where it can help implement correct color management, wide color gamut
+rendering and tonemapping.
 
-# Example
+## Example
 
 ```rust
 let conversion = kolor::ColorConversion::new(
     kolor::spaces::SRGB,
     kolor::spaces::ACES_CG,
 );
+
 let srgb_color = kolor::Vec3::new(0.25, 0.5, 0.75);
 let aces_cg_color = conversion.convert(srgb_color);
 ```
 
-# Design
-kolor aims to supports all color spaces and color models which use 3-component vectors,
-such as RGB, LAB, XYZ, HSL, LMS and more.
+## Design
 
-In the spirit of keeping things simple, kolor uses a single type, [ColorConversion](https://docs.rs/kolor/latest/kolor/struct.ColorConversion.html), to represent
-a color conversion between any supported color spaces.
+`kolor` aims to supports all color spaces and color models which use 3-component
+vectors, such as RGB, LAB, XYZ, HSL, LMS and more.
 
-For more details on design and implementation, please have a look at the [module docs.](https://docs.rs/kolor/latest/kolor/index.html)
+In the spirit of keeping things simple, kolor uses a single type,
+[ColorConversion](https://docs.rs/kolor/latest/kolor/struct.ColorConversion.html),
+to represent a color conversion between any supported color spaces.
 
-## no_std support
-kolor supports `no_std` by disabling the default-enabled `std` feature and enabling the `libm` feature.
+For more details on design and implementation, please have a look at the
+[module docs](https://docs.rs/kolor/latest/kolor/index.html).
 
-## f32 vs f64
-[kolor](https://crates.io/crates/kolor) uses 32-bit floats by default, and the f64 support is available in [kolor-64](https://crates.io/crates/kolor-64).
+### `no_std` Support
 
-### Contribution
+`kolor` supports `no_std` by disabling the default-enabled `std` feature and enabling the `libm` feature.
+
+### `f32` vs. `f64`
+
+[`kolor`](https://crates.io/crates/kolor) uses `f32` by default.
+
+The `f64` support is available in [`kolor-64`](https://crates.io/crates/kolor-64).
+
+## Contributions
 
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the Apache-2.0
@@ -44,9 +54,13 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT).
 
 Licensed under either of
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
 * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 
-PLEASE NOTE that some dependencies may be licensed under other terms. These are listed in [deny.toml](deny.toml) under licenses.exceptions on a best-effort basis, and are validated in every CI run using [cargo-deny](https://github.com/EmbarkStudios/cargo-deny).
+**Please note** that some dependencies may be licensed under *other* terms.
+These are listed in [deny.toml](deny.toml) under licenses.exceptions on a
+best-effort basis, and are validated in every CI run using
+[cargo-deny](https://github.com/EmbarkStudios/cargo-deny).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ let aces_cg_color = conversion.convert(srgb_color);
 vectors, such as RGB, LAB, XYZ, HSL, LMS and more.
 
 In the spirit of keeping things simple, kolor uses a single type,
-[ColorConversion](https://docs.rs/kolor/latest/kolor/struct.ColorConversion.html),
+[`ColorConversion`](https://docs.rs/kolor/latest/kolor/struct.ColorConversion.html),
 to represent a color conversion between any supported color spaces.
 
 For more details on design and implementation, please have a look at the
@@ -54,13 +54,14 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT).
 
 Licensed under either of
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
   http://www.apache.org/licenses/LICENSE-2.0)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 
-**Please note** that some dependencies may be licensed under *other* terms.
-These are listed in [deny.toml](deny.toml) under licenses.exceptions on a
+**Please note** that some dependencies may be licensed under _other_ terms.
+These are listed in [`deny.toml`](deny.toml) under licenses.exceptions on a
 best-effort basis, and are validated in every CI run using
-[cargo-deny](https://github.com/EmbarkStudios/cargo-deny).
+[`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny).

--- a/build/kolor-64/Cargo.toml
+++ b/build/kolor-64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kolor-64"
-version = "0.1.9"
+version = "0.2.0"
 authors = ["Karl Bergström <karl.anton.bergstrom@gmail.com>"]
 edition = "2021"
 description = "Color conversions for games & interactive applications."
@@ -16,16 +16,24 @@ path = "../../kolor/src/lib.rs"
 required-features = ["f64"]
 
 [dependencies]
+document-features = "0.2"
+glam = { version = "0.29", default-features = false, optional = true }
+num-traits = { version = "0.2", optional = true, default-features = false }
 serde = { optional = true, version = "1", features = ["derive"] }
-num-traits = { version = "^0.2.15", optional = true, default-features = false }
-glam = { version = "0.23", default-features = false, optional = true }
 
 [features]
-default = ["color-matrices", "f64", "std-glam"]
-serde1 = ["serde", "glam/serde"]
+default = ["std-glam", "color-matrices", "f64"]
+## Add a bunch of common color spaces.
 color-matrices = []
+## Use `f64` instead of `f32` for calculations.
 f64 = []
+## Add support for `serde`'s `Serialize` and `Deserialize` on `kolor` types.
+serde = ["dep:serde", "glam/serde"]
+## Enable `std` support.
 std = []
+## Enable `glam` with `std` support.
 std-glam = ["std", "glam/std"]
+## Enable [`libm`](https://docs.rs/libm) support.
 libm = ["num-traits", "num-traits/libm"]
+## Enable `glam` with `libm` support.
 libm-glam = ["libm", "glam/libm"]

--- a/build/kolor/Cargo.toml
+++ b/build/kolor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kolor"
-version = "0.1.9"
+version = "0.2.0"
 authors = ["Karl Bergström <karl.anton.bergstrom@gmail.com>"]
 edition = "2021"
 description = "Color conversions for games & interactive applications."
@@ -16,16 +16,24 @@ path = "../../kolor/src/lib.rs"
 required-features = ["f32"]
 
 [dependencies]
+document-features = "0.2"
+glam = { version = "0.29", default-features = false, optional = true }
+num-traits = { version = "0.2", optional = true, default-features = false }
 serde = { optional = true, version = "1", features = ["derive"] }
-num-traits = { version = "^0.2.15", optional = true, default-features = false }
-glam = { version = "0.23", default-features = false, optional = true }
 
 [features]
-default = ["color-matrices", "f32", "std-glam"]
-serde1 = ["serde", "glam/serde"]
+default = ["std-glam", "color-matrices", "f32"]
+## Add a bunch of common color spaces.
 color-matrices = []
+## Use `f64` instead of `f32` for calculations.
 f32 = []
+## Add support for `serde`'s `Serialize` and `Deserialize` on `kolor` types.
+serde = ["dep:serde", "glam/serde"]
+## Enable `std` support.
 std = []
+## Enable `glam` with `std` support.
 std-glam = ["std", "glam/std"]
+## Enable [`libm`](https://docs.rs/libm) support.
 libm = ["num-traits", "num-traits/libm"]
+## Enable `glam` with `libm` support.
 libm-glam = ["libm", "glam/libm"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,4 +12,4 @@ name = "all_examples"
 path = "./all_examples.rs"
 
 [dependencies]
-kolor = { path = "../build/kolor", version = "0.1.9" }
+kolor = { path = "../build/kolor", version = "0.2" }

--- a/examples/oklab.rs
+++ b/examples/oklab.rs
@@ -2,7 +2,7 @@ use kolor::{spaces, Color};
 
 pub fn example() {
     let srgb = Color::srgb(0.35, 0.75, 0.8);
-    let mut oklab = srgb.to(spaces::OKLAB);
+    let mut oklab = srgb.to(spaces::OK_LAB);
     // modify `a`
     oklab.value.y += 0.2;
     let modified_srgb = oklab.to(srgb.space);

--- a/kolor/src/details/cat.rs
+++ b/kolor/src/details/cat.rs
@@ -1,57 +1,65 @@
-//! Implements Chromatic Adaptation Transformation (CAT).
+//! Implements [Chromatic Adaptation](https://en.wikipedia.org/wiki/Chromatic_adaptation)
+//! Transformation (CAT).
 //!
-//! Chromatic Adaptation Transformation means transforming a linear
-//! color space's coordinate system from one white point reference to another.
+//! Chromatic Adaptation Transformation means transforming a linear color
+//! space's coordinate system from one white point reference to another.
 //!
-//! [LMSConeSpace] defines the set of supported conversion methods.
-//! [LMSConeSpace::Sharp] is used as a default for conversions by
-//! [ColorConversion][crate::details::conversion::ColorConversion].
+//! [`Sharp`(LmsConeSpace::Sharp) is used as the default for conversions by
+//! [`ColorConversion`][crate::details::conversion::ColorConversion].
 use crate::{Mat3, Vec3};
 
-pub enum LMSConeSpace {
+/// Supported conversion methods.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+pub enum LmsConeSpace {
     VonKries,
     Bradford,
+    #[default]
     Sharp,
     CmcCat2000,
     Cat02,
 }
-// from S. Bianco. "Two New von Kries Based
-// Chromatic Adapatation Transforms Found by Numerical Optimization."
-#[rustfmt::skip]
-pub fn lms_cone_space_matrix(cone_space: LMSConeSpace) -> Mat3 {
-    match cone_space {
-        LMSConeSpace::VonKries => {
-            Mat3::from_cols_array(&[0.40024, -0.2263, 0.0, 0.7076, 1.16532, 0.0, -0.08081, 0.0457, 0.91822])
-        }
-        LMSConeSpace::Bradford => {
-            Mat3::from_cols_array(&[0.8951, -0.7502, 0.0389, 0.2664, 1.7135, -0.0685, -0.1614, 0.0367, 1.0296])
-        }
-        LMSConeSpace::Sharp => {
-            Mat3::from_cols_array(&[1.2694, -0.8364, 0.0297, -0.0988, 1.8006, -0.0315, -0.1706, 0.0357, 1.0018])
-        }
-        LMSConeSpace::CmcCat2000 => {
-            Mat3::from_cols_array(&[0.7982, -0.5918, 0.0008, 0.3389, 1.5512, 0.239, -0.1371, 0.0406, 0.9753])
-        }
-        LMSConeSpace::Cat02 => {
-            Mat3::from_cols_array(&[0.7328, -0.7036, 0.0030, 0.4296, 1.6975, 0.0136, -0.1624, 0.0061, 0.9834])
+
+impl LmsConeSpace {
+    /// Returns the matrix for the given cone space variant.
+    // from S. Bianco. "Two New von Kries Based Chromatic Adapatation Transforms
+    // Found by Numerical Optimization."
+    #[rustfmt::skip]
+    pub fn matrix(&self) -> Mat3 {
+        match self {
+            LmsConeSpace::VonKries => {
+                Mat3::from_cols_array(&[0.40024, -0.2263, 0.0, 0.7076, 1.16532, 0.0, -0.08081, 0.0457, 0.91822])
+            }
+            LmsConeSpace::Bradford => {
+                Mat3::from_cols_array(&[0.8951, -0.7502, 0.0389, 0.2664, 1.7135, -0.0685, -0.1614, 0.0367, 1.0296])
+            }
+            LmsConeSpace::Sharp => {
+                Mat3::from_cols_array(&[1.2694, -0.8364, 0.0297, -0.0988, 1.8006, -0.0315, -0.1706, 0.0357, 1.0018])
+            }
+            LmsConeSpace::CmcCat2000 => {
+                Mat3::from_cols_array(&[0.7982, -0.5918, 0.0008, 0.3389, 1.5512, 0.239, -0.1371, 0.0406, 0.9753])
+            }
+            LmsConeSpace::Cat02 => {
+                Mat3::from_cols_array(&[0.7328, -0.7036, 0.0030, 0.4296, 1.6975, 0.0136, -0.1624, 0.0061, 0.9834])
+            }
         }
     }
-}
 
-#[rustfmt::skip]
-pub fn chromatic_adaptation_transform(
-    src_illuminant: Vec3,
-    dst_illuminant: Vec3,
-    cone_space: LMSConeSpace,
-) -> Mat3 {
-    let cone_space_transform = lms_cone_space_matrix(cone_space);
-    let src_cone_response = cone_space_transform * src_illuminant;
-    let dst_cone_response = cone_space_transform * dst_illuminant;
-    let src_to_dst_cone = Mat3::from_cols_array(&[
-        dst_cone_response.x / src_cone_response.x, 0.0, 0.0,
-        0.0, dst_cone_response.y / src_cone_response.y, 0.0,
-        0.0, 0.0, dst_cone_response.z / src_cone_response.z,
-    ]);
+    /// Calculate the CAT matrix for converting from one white point to another.
+    #[rustfmt::skip]
+    pub fn chromatic_adaptation_transform(
+        &self,
+        src_illuminant: Vec3,
+        dst_illuminant: Vec3,
+    ) -> Mat3 {
+        let cone_space_transform = self.matrix();
+        let src_cone_response = cone_space_transform * src_illuminant;
+        let dst_cone_response = cone_space_transform * dst_illuminant;
+        let src_to_dst_cone = Mat3::from_cols_array(&[
+            dst_cone_response.x / src_cone_response.x, 0.0, 0.0,
+            0.0, dst_cone_response.y / src_cone_response.y, 0.0,
+            0.0, 0.0, dst_cone_response.z / src_cone_response.z,
+        ]);
 
-    cone_space_transform.inverse() * src_to_dst_cone * cone_space_transform
+        cone_space_transform.inverse() * src_to_dst_cone * cone_space_transform
+    }
 }

--- a/kolor/src/details/color.rs
+++ b/kolor/src/details/color.rs
@@ -1,118 +1,122 @@
 use super::{conversion::ColorConversion, transform::ColorTransform};
-use crate::{FType, Vec3};
-#[cfg(feature = "serde1")]
+use crate::{Float, Vec3};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// A [TransformFn] identifies an invertible mapping of colors in a linear [ColorSpace].
+/// Identifies an invertible mapping of colors in a linear [`ColorSpace`].
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Hash, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
-#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TransformFn {
-    NONE,
-    /// The sRGB transfer functions (aka "gamma correction")
-    sRGB,
-    /// Oklab conversion from xyz
-    Oklab,
-    /// Oklch (Oklab's LCh variant) conversion from xyz
-    Oklch,
-    /// CIE xyY transform
-    CIE_xyY,
-    /// CIELAB transform
-    CIELAB,
-    /// CIELCh transform
-    CIELCh,
-    /// CIE 1960 UCS transform
-    CIE_1960_UCS,
-    /// CIE 1960 UCS transform in uvV form
-    CIE_1960_UCS_uvV,
-    /// CIE 1964 UVW transform
-    CIE_1964_UVW,
-    /// CIE 1976 Luv transform
-    CIE_1976_Luv,
-    /// (Hue, Saturation, Lightness),
-    /// where L is defined as the average of the largest and smallest color components
-    HSL,
+    None,
+    /// The sRGB transfer functions (aka 'gamma correction').
+    Srgb,
+    /// Oklab conversion from xyz.
+    OkLab,
+    /// Oklch (Oklab's LCh variant) conversion from xyz.
+    OkLch,
+    /// CIE xyY transform.
+    CieXyY,
+    /// CIELAB transform.
+    CieLab,
+    /// CIELCh transform.
+    CieLch,
+    /// CIE 1960 UCS transform.
+    Cie1960Ucs,
+    /// CIE 1960 UCS transform in uvV form.
+    Cie1960UcsUvV,
+    /// CIE 1964 UVW transform.
+    Cie1964Uvw,
+    /// CIE 1976 Luv transform.
+    Cie1976Luv,
+    /// (Hue, Saturation, Lightness), where L is defined as the average of the
+    /// largest and smallest color components.
+    Hsl,
     /// (Hue, Saturation, Value),
     /// where V is defined as the largest component of a color
-    HSV,
-    /// (Hue, Saturation, Intensity),
-    /// where I is defined as the average of the three components
-    HSI,
-    /// BT.2100 ICtCp with PQ transfer function
-    ICtCp_PQ,
-    /// BT.2100 ICtCp with HLG transfer function
-    ICtCp_HLG,
+    Hsv,
+    /// (Hue, Saturation, Intensity), where I is defined as the average of the
+    /// three components.
+    Hsi,
+    /// BT.2100 ICtCp with PQ transfer function.
+    IctCpPq,
+    /// BT.2100 ICtCp with HLG transfer function.
+    IctCpHlg,
     /// The BT.601/BT.709/BT.2020 (they are equivalent) OETF and inverse.
-    BT_601,
-    /// SMPTE ST 2084:2014 aka "Perceptual Quantizer" transfer functions used in BT.2100
-    /// for digitally created/distributed HDR content.
-    PQ,
+    Bt601,
+    /// SMPTE ST 2084:2014 aka "Perceptual Quantizer" transfer functions used in
+    /// BT.2100 for digitally created/distributed HDR content.
+    Pq,
     // ACEScc is a logarithmic transform
     // ACES_CC,
     // ACEScct is a logarithmic transform with toe
     // ACES_CCT,
 }
+
 impl TransformFn {
-    pub const ENUM_COUNT: TransformFn = TransformFn::ICtCp_HLG;
+    pub const ENUM_COUNT: TransformFn = TransformFn::Pq;
 }
-/// [RGBPrimaries] is a set of primary colors picked to define an RGB color space.
+
+/// A set of primary colors picked to define an RGB color space.
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Hash, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
-pub enum RGBPrimaries {
+pub enum RgbPrimaries {
     // Primaries
-    NONE,
+    None,
     /// BT.709 is the sRGB primaries.
-    BT_709,
-    // BT_2020 uses the same primaries as BT_2100
-    BT_2020,
-    AP0,
-    AP1,
-    /// P3 is the primaries for DCI-P3 and the variations with different white points
+    Bt709,
+    // BT 2020 uses the same primaries as BT 2100.
+    Bt2020,
+    Ap0,
+    Ap1,
+    /// P3 is the primaries for DCI-P3 and the variations with different white
+    /// points.
     P3,
-    ADOBE_1998,
-    ADOBE_WIDE,
-    APPLE,
-    PRO_PHOTO,
-    CIE_RGB,
+    Adobe1998,
+    AdobeWide,
+    Apple,
+    ProPhoto,
+    CieRgb,
     /// The reference XYZ color space
-    CIE_XYZ,
+    CieXyz,
 }
-impl RGBPrimaries {
-    pub const ENUM_COUNT: RGBPrimaries = RGBPrimaries::CIE_XYZ;
-    pub const fn values(&self) -> &[[FType; 2]; 3] {
+impl RgbPrimaries {
+    pub const ENUM_COUNT: RgbPrimaries = RgbPrimaries::CieXyz;
+
+    pub const fn values(&self) -> &[[Float; 2]; 3] {
         match self {
-            Self::NONE => &[[0.0; 2]; 3],
-            Self::BT_709 => &[[0.64, 0.33], [0.30, 0.60], [0.15, 0.06]],
-            Self::BT_2020 => &[[0.708, 0.292], [0.17, 0.797], [0.131, 0.046]],
-            Self::AP0 => &[[0.7347, 0.2653], [0.0000, 1.0000], [0.0001, -0.0770]],
-            Self::AP1 => &[[0.713, 0.293], [0.165, 0.830], [0.128, 0.044]],
-            Self::ADOBE_1998 => &[[0.64, 0.33], [0.21, 0.71], [0.15, 0.06]],
-            Self::ADOBE_WIDE => &[[0.735, 0.265], [0.115, 0.826], [0.157, 0.018]],
-            Self::PRO_PHOTO => &[
+            Self::None => &[[0.0; 2]; 3],
+            Self::Bt709 => &[[0.64, 0.33], [0.30, 0.60], [0.15, 0.06]],
+            Self::Bt2020 => &[[0.708, 0.292], [0.17, 0.797], [0.131, 0.046]],
+            Self::Ap0 => &[[0.7347, 0.2653], [0.0000, 1.0000], [0.0001, -0.0770]],
+            Self::Ap1 => &[[0.713, 0.293], [0.165, 0.830], [0.128, 0.044]],
+            Self::Adobe1998 => &[[0.64, 0.33], [0.21, 0.71], [0.15, 0.06]],
+            Self::AdobeWide => &[[0.735, 0.265], [0.115, 0.826], [0.157, 0.018]],
+            Self::ProPhoto => &[
                 [0.734699, 0.265301],
                 [0.159597, 0.840403],
                 [0.036598, 0.000105],
             ],
-            Self::APPLE => &[[0.625, 0.34], [0.28, 0.595], [0.155, 0.07]],
+            Self::Apple => &[[0.625, 0.34], [0.28, 0.595], [0.155, 0.07]],
             Self::P3 => &[[0.680, 0.320], [0.265, 0.690], [0.150, 0.060]],
-            Self::CIE_RGB => &[[0.7350, 0.2650], [0.2740, 0.7170], [0.1670, 0.0090]],
-            Self::CIE_XYZ => &[[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
+            Self::CieRgb => &[[0.7350, 0.2650], [0.2740, 0.7170], [0.1670, 0.0090]],
+            Self::CieXyz => &[[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
         }
     }
 }
 
-/// A [WhitePoint] defines the color white ("achromatic point") in an RGB color system.
+/// Defines the color white ("achromatic point") in an RGB color system.
+///
 /// White points are derived from an "illuminant" which are defined
 /// as some reference lighting condition based on a Spectral Power Distribution.
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Hash, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 pub enum WhitePoint {
-    NONE,
+    None,
     /// Incandescent/tungsten
     A,
     /// Old direct sunlight at noon
@@ -131,7 +135,7 @@ pub enum WhitePoint {
     /// North sky daylight
     D75,
     /// P3-DCI white point, sort of greenish
-    P3_DCI,
+    P3Dci,
     /// Cool fluorescent
     F2,
     /// Daylight fluorescent, D65 simulator
@@ -141,12 +145,13 @@ pub enum WhitePoint {
 }
 impl WhitePoint {
     pub const ENUM_COUNT: WhitePoint = WhitePoint::F11;
+
     // Pulled from http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html
-    // Originally from ASTM E308-01 except B which comes from Wyszecki & Stiles, p. 769
-    // P3_DCI is something I calculated myself from wikipedia constants
-    pub const fn values(&self) -> &'static [FType; 3] {
+    // Originally from ASTM E308-01 except B which comes from Wyszecki & Stiles, p.
+    // 769 P3Dci is something I calculated myself from wikipedia constants
+    pub const fn values(&self) -> &'static [Float; 3] {
         match self {
-            Self::NONE => &[0.0, 0.0, 0.0],
+            Self::None => &[0.0, 0.0, 0.0],
             Self::A => &[1.09850, 1.00000, 0.35585],
             Self::B => &[0.99072, 1.00000, 0.85223],
             Self::C => &[0.98074, 1.00000, 1.18232],
@@ -156,7 +161,7 @@ impl WhitePoint {
             Self::D65 => &[0.95047, 1.00000, 1.08883],
             Self::D75 => &[0.94972, 1.00000, 1.22638],
             #[allow(clippy::excessive_precision)]
-            Self::P3_DCI => &[0.89458689458, 1.00000, 0.95441595441],
+            Self::P3Dci => &[0.89458689458, 1.00000, 0.95441595441],
             Self::E => &[1.00000, 1.00000, 1.00000],
             Self::F2 => &[0.99186, 1.00000, 0.67393],
             Self::F7 => &[0.95041, 1.00000, 1.08747],
@@ -165,39 +170,49 @@ impl WhitePoint {
     }
 }
 
-/// A color space defined in data by its [Primaries][RGBPrimaries], [white point][WhitePoint], and an optional [invertible transform function][TransformFn].
+/// A color space defined in data by its [primaries][RgbPrimaries], [white
+/// point][WhitePoint], and an optional [invertible transform
+/// function][TransformFn].
 ///
-/// See [spaces][crate::spaces] for defined color spaces.
+/// See the [`spaces`][crate::spaces] module for defined color spaces.
 ///
-/// [ColorSpace] assumes that a color space is one of
-/// - the CIE XYZ color space
-/// - an RGB color space
-/// - a color space which may be defined as an invertible mapping from one the above ([TransformFn])
+/// `ColorSpace` assumes that a color space is one of:
 ///
-/// An example of a [TransformFn] is the sRGB "opto-eletronic transfer function", or
-/// "gamma compensation".
+/// * The CIE XYZ color space.
 ///
-/// `kolor` makes the distinction between "linear" and "non-linear" color spaces, where a linear
-/// color space can be defined as a linear transformation from the CIE XYZ color space.
+/// * An RGB color space.
 ///
-/// [ColorSpace] contains a reference [WhitePoint] to represent a color space's reference illuminant.
+/// * A color space which may be defined as an invertible mapping from one of
+///   the above ([`TransformFn`]).
 ///
-/// A linear RGB [ColorSpace] can be thought of as defining a relative coordinate system in the CIE XYZ
-/// color coordinate space, where three RGB primaries each define an axis pointing from
-/// the black point (0,0,0) in CIE XYZ.
+/// An example of a `TransformFn` is the sRGB "opto-eletronic transfer
+/// function", or 'gamma compensation'.
 ///
-/// Non-linear [ColorSpace]s - such as sRGB with gamma compensation applied - are defined as a non-linear mapping from a linear
-/// [ColorSpace]'s coordinate system.
+/// `kolor` makes the distinction between 'linear' and 'non-linear' color
+/// spaces, where a linear color space can be defined as a linear transformation
+/// from the CIE XYZ color space.
+///
+/// `ColorSpace` contains a reference [WhitePoint] to represent a color space's
+/// reference illuminant.
+///
+/// A linear RGB `ColorSpace` can be thought of as defining a relative
+/// coordinate system in the CIE XYZ color coordinate space, where three RGB
+/// primaries each define an axis pointing from the black point (0,0,0) in CIE
+/// XYZ.
+///
+/// Non-linear `ColorSpace`s -- such as sRGB with gamma compensation applied --
+/// are defined as a non-linear mapping from a linear `ColorSpace`'s coordinate
+/// system.
 #[derive(Debug, Copy, Clone, PartialEq, Hash, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ColorSpace {
-    primaries: RGBPrimaries,
+    primaries: RgbPrimaries,
     white_point: WhitePoint,
     transform_fn: TransformFn,
 }
 impl ColorSpace {
     pub const fn new(
-        primaries: RGBPrimaries,
+        primaries: RgbPrimaries,
         white_point: WhitePoint,
         transform_fn: TransformFn,
     ) -> Self {
@@ -207,36 +222,42 @@ impl ColorSpace {
             transform_fn,
         }
     }
-    pub(crate) const fn linear(primaries: RGBPrimaries, white_point: WhitePoint) -> Self {
+
+    pub(crate) const fn linear(primaries: RgbPrimaries, white_point: WhitePoint) -> Self {
         Self {
             primaries,
             white_point,
-            transform_fn: TransformFn::NONE,
+            transform_fn: TransformFn::None,
         }
     }
+
     /// Whether the color space has a non-linear transform applied
     pub fn is_linear(&self) -> bool {
-        self.transform_fn == TransformFn::NONE
+        self.transform_fn == TransformFn::None
     }
+
     pub fn as_linear(&self) -> Self {
         Self {
             primaries: self.primaries,
             white_point: self.white_point,
-            transform_fn: TransformFn::NONE,
+            transform_fn: TransformFn::None,
         }
     }
-    pub fn primaries(&self) -> RGBPrimaries {
+
+    pub fn primaries(&self) -> RgbPrimaries {
         self.primaries
     }
+
     pub fn white_point(&self) -> WhitePoint {
         self.white_point
     }
+
     pub fn transform_function(&self) -> TransformFn {
         self.transform_fn
     }
 
-    /// Creates a new color space with the primaries and white point from `this`,
-    /// but with the provided [TransformFn].
+    /// Creates a new color space with the primaries and white point from
+    /// `this`, but with the provided [`TransformFn`].
     pub fn with_transform(&self, new_transform: TransformFn) -> Self {
         Self {
             primaries: self.primaries,
@@ -245,8 +266,8 @@ impl ColorSpace {
         }
     }
 
-    /// Creates a new color space with the transform function and white point from `this`,
-    /// but with the provided [WhitePoint].
+    /// Creates a new color space with the transform function and white point
+    /// from `this`, but with the provided [`WhitePoint`].
     pub fn with_whitepoint(&self, new_wp: WhitePoint) -> Self {
         Self {
             primaries: self.primaries,
@@ -255,9 +276,9 @@ impl ColorSpace {
         }
     }
 
-    /// Creates a new color space with the primaries and transform function from `this`,
-    /// but with the provided [RGBPrimaries].
-    pub fn with_primaries(&self, primaries: RGBPrimaries) -> Self {
+    /// Creates a new color space with the primaries and transform function from
+    /// `this`, but with the provided [`RgbPrimaries`].
+    pub fn with_primaries(&self, primaries: RgbPrimaries) -> Self {
         Self {
             primaries,
             white_point: self.white_point,
@@ -266,144 +287,151 @@ impl ColorSpace {
     }
 
     /// Creates a CIE LAB color space using this space's white point.
-    pub fn to_cielab(&self) -> Self {
-        Self::new(RGBPrimaries::CIE_XYZ, self.white_point, TransformFn::CIELAB)
+    pub fn to_cie_lab(&self) -> Self {
+        Self::new(RgbPrimaries::CieXyz, self.white_point, TransformFn::CieLab)
     }
 
     /// Creates a CIE uvV color space using this space's white point.
-    #[allow(non_snake_case)]
-    pub fn to_cie_xyY(&self) -> Self {
-        Self::new(
-            RGBPrimaries::CIE_XYZ,
-            self.white_point,
-            TransformFn::CIE_xyY,
-        )
+    pub fn to_cie_xyy(&self) -> Self {
+        Self::new(RgbPrimaries::CieXyz, self.white_point, TransformFn::CieXyY)
     }
 
     /// Creates a CIE LCh color space using this space's white point.
-    pub fn to_cielch(&self) -> Self {
-        Self::new(RGBPrimaries::CIE_XYZ, self.white_point, TransformFn::CIELCh)
+    pub fn to_cie_lch(&self) -> Self {
+        Self::new(RgbPrimaries::CieXyz, self.white_point, TransformFn::CieLch)
     }
 }
-#[allow(non_upper_case_globals)]
+
 pub mod color_spaces {
     use super::*;
 
-    /// Linear sRGB is a linear encoding in [BT.709 primaries][RGBPrimaries::BT_709]
-    /// with a [D65 whitepoint.][WhitePoint::D65]
-    /// Linear sRGB is equivalent to [BT_709].
-    pub const LINEAR_SRGB: ColorSpace = ColorSpace::linear(RGBPrimaries::BT_709, WhitePoint::D65);
+    /// Linear sRGB is a linear encoding in [BT.709
+    /// primaries][RgbPrimaries::Bt709] with a [D65
+    /// whitepoint.][WhitePoint::D65] Linear sRGB is equivalent to [BT_709].
+    pub const LINEAR_SRGB: ColorSpace = ColorSpace::linear(RgbPrimaries::Bt709, WhitePoint::D65);
 
-    /// Encoded sRGB is [Linear sRGB][LINEAR_SRGB] with the [sRGB OETF](TransformFn::sRGB) applied (also called "gamma-compressed").
+    /// Encoded sRGB is [linear sRGB][LINEAR_SRGB] with the [sRGB
+    /// OETF](TransformFn::Srgb) applied (also called 'gamma-compressed').
     pub const ENCODED_SRGB: ColorSpace =
-        ColorSpace::new(RGBPrimaries::BT_709, WhitePoint::D65, TransformFn::sRGB);
+        ColorSpace::new(RgbPrimaries::Bt709, WhitePoint::D65, TransformFn::Srgb);
 
-    /// BT.709 is a linear encoding in [BT.709 primaries][RGBPrimaries::BT_709]
-    /// with a [D65 whitepoint.][WhitePoint::D65]. It's equivalent to [Linear sRGB][LINEAR_SRGB]
-    pub const BT_709: ColorSpace = ColorSpace::linear(RGBPrimaries::BT_709, WhitePoint::D65);
+    /// BT.709 is a linear encoding in [BT.709 primaries][RgbPrimaries::Bt709]
+    /// with a [D65 whitepoint.][WhitePoint::D65]. It's equivalent to [Linear
+    /// sRGB][LINEAR_SRGB]
+    pub const BT_709: ColorSpace = ColorSpace::linear(RgbPrimaries::Bt709, WhitePoint::D65);
 
-    /// Encoded BT.709 is [BT.709](BT_709) with the [BT.709 OETF](TransformFn::BT_601) applied.
+    /// Encoded BT.709 is [BT.709](BT_709) with the [BT.709
+    /// OETF](TransformFn::Bt601) applied.
     pub const ENCODED_BT_709: ColorSpace =
-        ColorSpace::new(RGBPrimaries::BT_709, WhitePoint::D65, TransformFn::BT_601);
+        ColorSpace::new(RgbPrimaries::Bt709, WhitePoint::D65, TransformFn::Bt601);
 
-    /// ACEScg is a linear encoding in [AP1 primaries][RGBPrimaries::AP1]
+    /// ACEScg is a linear encoding in [AP1 primaries][RgbPrimaries::Ap1]
     /// with a [D60 whitepoint][WhitePoint::D60].
-    pub const ACES_CG: ColorSpace = ColorSpace::linear(RGBPrimaries::AP1, WhitePoint::D60);
+    pub const ACES_CG: ColorSpace = ColorSpace::linear(RgbPrimaries::Ap1, WhitePoint::D60);
 
-    /// ACES2065-1 is a linear encoding in [AP0 primaries][RGBPrimaries::AP0] with a [D60 whitepoint][WhitePoint::D60].
-    pub const ACES2065_1: ColorSpace = ColorSpace::linear(RGBPrimaries::AP0, WhitePoint::D60);
+    /// ACES2065-1 is a linear encoding in [AP0 primaries][RgbPrimaries::Ap0]
+    /// with a [D60 whitepoint][WhitePoint::D60].
+    pub const ACES_2065_1: ColorSpace = ColorSpace::linear(RgbPrimaries::Ap0, WhitePoint::D60);
 
-    /// CIE RGB is the original RGB space, defined in [CIE RGB primaries][RGBPrimaries::CIE_RGB]
-    /// with white point [E][WhitePoint::E].
-    pub const CIE_RGB: ColorSpace = ColorSpace::linear(RGBPrimaries::CIE_RGB, WhitePoint::E);
+    /// CIE RGB is the original RGB space, defined in [CIE RGB
+    /// primaries][RgbPrimaries::CieRgb] with white point
+    /// [E][WhitePoint::E].
+    pub const CIE_RGB: ColorSpace = ColorSpace::linear(RgbPrimaries::CieRgb, WhitePoint::E);
 
-    /// CIE XYZ reference color space. Uses [CIE XYZ primaries][RGBPrimaries::CIE_XYZ]
-    /// with white point [D65][WhitePoint::D65].
-    pub const CIE_XYZ: ColorSpace = ColorSpace::linear(RGBPrimaries::CIE_XYZ, WhitePoint::D65);
+    /// CIE XYZ reference color space. Uses [CIE XYZ
+    /// primaries][RgbPrimaries::CieXyz] with white point
+    /// [D65][WhitePoint::D65].
+    pub const CIE_XYZ: ColorSpace = ColorSpace::linear(RgbPrimaries::CieXyz, WhitePoint::D65);
 
-    /// BT.2020 is a linear encoding in [BT.2020 primaries][RGBPrimaries::BT_2020]
-    /// with a [D65 white point][WhitePoint::D65]
-    /// BT.2100 has the same linear color space as BT.2020.
-    pub const BT_2020: ColorSpace = ColorSpace::linear(RGBPrimaries::BT_2020, WhitePoint::D65);
+    /// BT.2020 is a linear encoding in [BT.2020
+    /// primaries][RgbPrimaries::Bt2020] with a [D65 white
+    /// point][WhitePoint::D65] BT.2100 has the same linear color space as
+    /// BT.2020.
+    pub const BT_2020: ColorSpace = ColorSpace::linear(RgbPrimaries::Bt2020, WhitePoint::D65);
 
-    /// Encoded BT.2020 is [BT.2020](BT_2020) with the [BT.2020 OETF][TransformFn::BT_601] applied.
+    /// Encoded BT.2020 is [BT.2020](BT_2020) with the [BT.2020
+    /// OETF][TransformFn::Bt601] applied.
     pub const ENCODED_BT_2020: ColorSpace =
-        ColorSpace::new(RGBPrimaries::BT_2020, WhitePoint::D65, TransformFn::BT_601);
+        ColorSpace::new(RgbPrimaries::Bt2020, WhitePoint::D65, TransformFn::Bt601);
 
-    /// Encoded BT.2100 PQ is [BT.2020](BT_2020) (equivalent to the linear BT.2100 space) with
-    /// the [Perceptual Quantizer inverse EOTF][TransformFn::PQ] applied.
+    /// Encoded BT.2100 PQ is [BT.2020](BT_2020) (equivalent to the linear
+    /// BT.2100 space) with the [Perceptual Quantizer inverse
+    /// EOTF][TransformFn::Pq] applied.
     pub const ENCODED_BT_2100_PQ: ColorSpace =
-        ColorSpace::new(RGBPrimaries::BT_2020, WhitePoint::D65, TransformFn::PQ);
+        ColorSpace::new(RgbPrimaries::Bt2020, WhitePoint::D65, TransformFn::Pq);
 
-    /// Oklab is a non-linear, perceptual encoding in [XYZ][RGBPrimaries::CIE_XYZ],
-    /// with a [D65 whitepoint][WhitePoint::D65].
+    /// Oklab is a non-linear, perceptual encoding in
+    /// [XYZ][RgbPrimaries::CieXyz], with a [D65 whitepoint][WhitePoint::D65].
     ///
-    /// Oklab's perceptual qualities make it a very attractive color space for performing
-    /// blend operations between two colors which you want to be perceptually pleasing.
-    /// See [this article](https://bottosson.github.io/posts/oklab/)
+    /// Oklab's perceptual qualities make it a very attractive color space for
+    /// performing blend operations between two colors which you want to be
+    /// perceptually pleasing. See [this article](https://bottosson.github.io/posts/oklab/)
     /// for more on why you might want to use the Oklab colorspace.
-    pub const OKLAB: ColorSpace =
-        ColorSpace::new(RGBPrimaries::CIE_XYZ, WhitePoint::D65, TransformFn::Oklab);
+    pub const OK_LAB: ColorSpace =
+        ColorSpace::new(RgbPrimaries::CieXyz, WhitePoint::D65, TransformFn::OkLab);
 
-    /// Oklch is a non-linear, perceptual encoding in [XYZ][RGBPrimaries::CIE_XYZ],
-    /// with a [D65 whitepoint][WhitePoint::D65]. It is a variant of [Oklab][OKLAB]
-    /// with LCh coordinates intead of Lab.
+    /// Oklch is a non-linear, perceptual encoding in
+    /// [XYZ][RgbPrimaries::CieXyz], with a [D65
+    /// whitepoint][WhitePoint::D65]. It is a variant of [Oklab](OK_LAB) with
+    /// LCh coordinates intead of Lab.
     ///
     /// Oklch's qualities make it a very attractive color space for performing
-    /// computational modifications to a color. You can think of it as an improved
-    /// version of an HSL/HSV-style color space. See [this article](https://bottosson.github.io/posts/oklab/)
-    /// for more on why you might want to use the Oklch colorspace.
-    pub const OKLCH: ColorSpace =
-        ColorSpace::new(RGBPrimaries::CIE_XYZ, WhitePoint::D65, TransformFn::Oklch);
+    /// computational modifications to a color. You can think of it as an
+    /// improved version of an HSL/HSV-style color space. See
+    /// [this article](https://bottosson.github.io/posts/oklab/) for more on why
+    /// you might want to use the Oklch colorspace.
+    pub const OK_LCH: ColorSpace =
+        ColorSpace::new(RgbPrimaries::CieXyz, WhitePoint::D65, TransformFn::OkLch);
 
-    /// ICtCp_PQ is a non-linear encoding in [BT.2020 primaries][RGBPrimaries::BT_2020],
-    /// with a [D65 whitepoint][WhitePoint::D65], using the PQ transfer function
-    pub const ICtCp_PQ: ColorSpace = ColorSpace::new(
-        RGBPrimaries::BT_2020,
-        WhitePoint::D65,
-        TransformFn::ICtCp_PQ,
-    );
-    /// ICtCp_HLG is a non-linear encoding in [BT.2020 primaries][RGBPrimaries::BT_2020],
-    /// with a [D65 whitepoint][WhitePoint::D65], using the HLG transfer function
-    pub const ICtCp_HLG: ColorSpace = ColorSpace::new(
-        RGBPrimaries::BT_2020,
-        WhitePoint::D65,
-        TransformFn::ICtCp_HLG,
-    );
+    /// ICtCp_PQ is a non-linear encoding in [BT.2020
+    /// primaries][RgbPrimaries::Bt2020], with a [D65
+    /// whitepoint][WhitePoint::D65], using the PQ transfer function
+    pub const ICT_CP_PQ: ColorSpace =
+        ColorSpace::new(RgbPrimaries::Bt2020, WhitePoint::D65, TransformFn::IctCpPq);
+    /// ICtCp_HLG is a non-linear encoding in [BT.2020
+    /// primaries][RgbPrimaries::Bt2020], with a [D65
+    /// whitepoint][WhitePoint::D65], using the HLG transfer function
+    pub const ICT_CP_HLG: ColorSpace =
+        ColorSpace::new(RgbPrimaries::Bt2020, WhitePoint::D65, TransformFn::IctCpHlg);
 
-    /// Encoded Display P3 is [Display P3][DISPLAY_P3] with the [sRGB OETF](TransformFn::sRGB) applied.
+    /// Encoded Display P3 is [Display P3][DISPLAY_P3] with the [sRGB
+    /// OETF](TransformFn::Srgb) applied.
     pub const ENCODED_DISPLAY_P3: ColorSpace =
-        ColorSpace::new(RGBPrimaries::P3, WhitePoint::D65, TransformFn::sRGB);
+        ColorSpace::new(RgbPrimaries::P3, WhitePoint::D65, TransformFn::Srgb);
 
-    /// Display P3 by Apple is a linear encoding in [P3 primaries][RGBPrimaries::P3]
+    /// Display P3 by Apple is a linear encoding in [P3
+    /// primaries][RgbPrimaries::P3] with a [D65 white
+    /// point][WhitePoint::D65]
+    pub const DISPLAY_P3: ColorSpace = ColorSpace::linear(RgbPrimaries::P3, WhitePoint::D65);
+
+    /// P3-D60 (ACES Cinema) is a linear encoding in [P3
+    /// primaries][RgbPrimaries::P3] with a [D60 white
+    /// point][WhitePoint::D60]
+    pub const P3_D60: ColorSpace = ColorSpace::linear(RgbPrimaries::P3, WhitePoint::D60);
+
+    /// P3-DCI (Theater) is a linear encoding in [P3
+    /// primaries][RgbPrimaries::P3] with a [P3-DCI white
+    /// point][WhitePoint::P3Dci]
+    pub const P3_THEATER: ColorSpace = ColorSpace::linear(RgbPrimaries::P3, WhitePoint::P3Dci);
+
+    /// Adobe RGB (1998) is a linear encoding in [Adobe 1998
+    /// primaries][RgbPrimaries::Adobe1998] with a [D65 white
+    /// point][WhitePoint::D65]
+    pub const ADOBE_1998: ColorSpace = ColorSpace::linear(RgbPrimaries::Adobe1998, WhitePoint::D65);
+
+    /// Adobe Wide Gamut RGB is a linear encoding in [Adobe Wide
+    /// primaries][RgbPrimaries::AdobeWide] with a [D50 white
+    /// point][WhitePoint::D50]
+    pub const ADOBE_WIDE: ColorSpace = ColorSpace::linear(RgbPrimaries::AdobeWide, WhitePoint::D50);
+
+    /// Pro Photo RGB is a linear encoding in [Pro Photo
+    /// primaries][RgbPrimaries::ProPhoto] with a [D50 white
+    /// point][WhitePoint::D50]
+    pub const PRO_PHOTO: ColorSpace = ColorSpace::linear(RgbPrimaries::ProPhoto, WhitePoint::D50);
+
+    /// Apple RGB is a linear encoding in [Apple primaries][RgbPrimaries::Apple]
     /// with a [D65 white point][WhitePoint::D65]
-    pub const DISPLAY_P3: ColorSpace = ColorSpace::linear(RGBPrimaries::P3, WhitePoint::D65);
-
-    /// P3-D60 (ACES Cinema) is a linear encoding in [P3 primaries][RGBPrimaries::P3]
-    /// with a [D60 white point][WhitePoint::D60]
-    pub const P3_D60: ColorSpace = ColorSpace::linear(RGBPrimaries::P3, WhitePoint::D60);
-
-    /// P3-DCI (Theater) is a linear encoding in [P3 primaries][RGBPrimaries::P3]
-    /// with a [P3-DCI white point][WhitePoint::P3_DCI]
-    pub const P3_THEATER: ColorSpace = ColorSpace::linear(RGBPrimaries::P3, WhitePoint::P3_DCI);
-
-    /// Adobe RGB (1998) is a linear encoding in [Adobe 1998 primaries][RGBPrimaries::ADOBE_1998]
-    /// with a [D65 white point][WhitePoint::D65]
-    pub const ADOBE_1998: ColorSpace =
-        ColorSpace::linear(RGBPrimaries::ADOBE_1998, WhitePoint::D65);
-
-    /// Adobe Wide Gamut RGB is a linear encoding in [Adobe Wide primaries][RGBPrimaries::ADOBE_WIDE]
-    /// with a [D50 white point][WhitePoint::D50]
-    pub const ADOBE_WIDE: ColorSpace =
-        ColorSpace::linear(RGBPrimaries::ADOBE_WIDE, WhitePoint::D50);
-
-    /// Pro Photo RGB is a linear encoding in [Pro Photo primaries][RGBPrimaries::PRO_PHOTO]
-    /// with a [D50 white point][WhitePoint::D50]
-    pub const PRO_PHOTO: ColorSpace = ColorSpace::linear(RGBPrimaries::PRO_PHOTO, WhitePoint::D50);
-
-    /// Apple RGB is a linear encoding in [Apple primaries][RGBPrimaries::APPLE]
-    /// with a [D65 white point][WhitePoint::D65]
-    pub const APPLE: ColorSpace = ColorSpace::linear(RGBPrimaries::APPLE, WhitePoint::D65);
+    pub const APPLE: ColorSpace = ColorSpace::linear(RgbPrimaries::Apple, WhitePoint::D65);
 
     /// Array containing all built-in color spaces.
     pub const ALL_COLOR_SPACES: [ColorSpace; 22] = [
@@ -415,12 +443,12 @@ pub mod color_spaces {
         color_spaces::ENCODED_BT_2020,
         color_spaces::ENCODED_BT_2100_PQ,
         color_spaces::ACES_CG,
-        color_spaces::ACES2065_1,
+        color_spaces::ACES_2065_1,
         color_spaces::CIE_RGB,
         color_spaces::CIE_XYZ,
-        color_spaces::OKLAB,
-        color_spaces::ICtCp_PQ,
-        color_spaces::ICtCp_HLG,
+        color_spaces::OK_LAB,
+        color_spaces::ICT_CP_PQ,
+        color_spaces::ICT_CP_HLG,
         color_spaces::PRO_PHOTO,
         color_spaces::APPLE,
         color_spaces::P3_D60,
@@ -432,15 +460,15 @@ pub mod color_spaces {
     ];
 }
 
-/// [Color] is a 3-component vector defined in a [ColorSpace].
+/// A 3-component vector defined in a [`ColorSpace`].
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Color {
     pub value: Vec3,
     pub space: ColorSpace,
 }
 impl Color {
-    pub const fn new(x: FType, y: FType, z: FType, space: ColorSpace) -> Self {
+    pub const fn new(x: Float, y: Float, z: Float, space: ColorSpace) -> Self {
         #[cfg(all(feature = "glam", feature = "f64"))]
         return Self {
             value: glam::f64::DVec3::new(x, y, z),
@@ -457,12 +485,13 @@ impl Color {
             space,
         };
     }
+
     pub const fn space(&self) -> ColorSpace {
         self.space
     }
 
     /// Equivalent to `Color::new(x, y, z, kolor::spaces::ENCODED_SRGB)`
-    pub const fn srgb(x: FType, y: FType, z: FType) -> Self {
+    pub const fn srgb(x: Float, y: Float, z: Float) -> Self {
         #[cfg(all(feature = "glam", feature = "f64"))]
         return Self {
             value: glam::f64::DVec3::new(x, y, z),
@@ -480,7 +509,7 @@ impl Color {
         };
     }
 
-    /// Returns a [Color] with this color converted into the provided [ColorSpace].
+    /// Returns a `Color` converted into the provided [`ColorSpace`].
     pub fn to(&self, space: ColorSpace) -> Color {
         let conversion = ColorConversion::new(self.space, space);
         let new_color = conversion.convert(self.value);
@@ -489,11 +518,12 @@ impl Color {
             value: new_color,
         }
     }
+
     pub fn to_linear(&self) -> Color {
         if self.space.is_linear() {
             *self
         } else {
-            let transform = ColorTransform::new(self.space.transform_function(), TransformFn::NONE)
+            let transform = ColorTransform::new(self.space.transform_function(), TransformFn::None)
                 .unwrap_or_else(|| {
                     panic!(
                         "expected transform for {:?}",
@@ -510,7 +540,6 @@ impl Color {
 }
 
 #[cfg(test)]
-#[allow(non_snake_case)]
 mod test {
     use super::*;
     use crate::details::conversion::LinearColorConversion;
@@ -524,14 +553,14 @@ mod test {
 
     #[test]
     fn linear_srgb_to_aces_2065_1() {
-        let conversion = ColorConversion::new(spaces::LINEAR_SRGB, spaces::ACES2065_1);
+        let conversion = ColorConversion::new(spaces::LINEAR_SRGB, spaces::ACES_2065_1);
         let result = conversion.convert(Vec3::new(0.35, 0.2, 0.8));
         assert!(result.abs_diff_eq(Vec3::new(0.3741492, 0.27154857, 0.7261116), 0.001));
     }
 
     #[test]
     fn linear_srgb_to_srgb() {
-        let transform = ColorTransform::new(TransformFn::NONE, TransformFn::sRGB).unwrap();
+        let transform = ColorTransform::new(TransformFn::None, TransformFn::Srgb).unwrap();
         let test = Vec3::new(0.35, 0.1, 0.8);
         let result = transform.apply(test, WhitePoint::D65);
         let expected = Vec3::new(0.6262097, 0.34919018, 0.9063317);

--- a/kolor/src/details/generated_matrices.rs
+++ b/kolor/src/details/generated_matrices.rs
@@ -1,4 +1,4 @@
-use super::color::{RGBPrimaries, WhitePoint};
+use super::color::{RgbPrimaries, WhitePoint};
 use crate::Mat3;
 
 #[rustfmt::skip]
@@ -1094,481 +1094,481 @@ pub const ADOBE_WIDE_D50_TO_ADOBE_1998_D65: Mat3 = Mat3::from_cols_array(&[
 ]);
 
 pub fn const_conversion_matrix(
-    src_primaries: RGBPrimaries,
+    src_primaries: RgbPrimaries,
     src_wp: WhitePoint,
-    dst_primaries: RGBPrimaries,
+    dst_primaries: RgbPrimaries,
     dst_wp: WhitePoint,
 ) -> Option<Mat3> {
     if src_primaries == dst_primaries && src_wp == dst_wp {
         return Some(Mat3::IDENTITY);
     }
     match (src_primaries, src_wp, dst_primaries, dst_wp) {
-        (RGBPrimaries::BT_709, WhitePoint::D65, RGBPrimaries::BT_2020, WhitePoint::D65) => {
+        (RgbPrimaries::Bt709, WhitePoint::D65, RgbPrimaries::Bt2020, WhitePoint::D65) => {
             Some(BT_709_D65_TO_BT_2020_D65)
         }
-        (RGBPrimaries::BT_709, WhitePoint::D65, RGBPrimaries::AP1, WhitePoint::D60) => {
+        (RgbPrimaries::Bt709, WhitePoint::D65, RgbPrimaries::Ap1, WhitePoint::D60) => {
             Some(BT_709_D65_TO_AP1_D60)
         }
-        (RGBPrimaries::BT_709, WhitePoint::D65, RGBPrimaries::AP0, WhitePoint::D60) => {
+        (RgbPrimaries::Bt709, WhitePoint::D65, RgbPrimaries::Ap0, WhitePoint::D60) => {
             Some(BT_709_D65_TO_AP0_D60)
         }
-        (RGBPrimaries::BT_709, WhitePoint::D65, RGBPrimaries::CIE_RGB, WhitePoint::E) => {
+        (RgbPrimaries::Bt709, WhitePoint::D65, RgbPrimaries::CieRgb, WhitePoint::E) => {
             Some(BT_709_D65_TO_CIE_RGB_E)
         }
-        (RGBPrimaries::BT_709, WhitePoint::D65, RGBPrimaries::CIE_XYZ, WhitePoint::D65) => {
+        (RgbPrimaries::Bt709, WhitePoint::D65, RgbPrimaries::CieXyz, WhitePoint::D65) => {
             Some(BT_709_D65_TO_CIE_XYZ_D65)
         }
-        (RGBPrimaries::BT_709, WhitePoint::D65, RGBPrimaries::PRO_PHOTO, WhitePoint::D50) => {
+        (RgbPrimaries::Bt709, WhitePoint::D65, RgbPrimaries::ProPhoto, WhitePoint::D50) => {
             Some(BT_709_D65_TO_PRO_PHOTO_D50)
         }
-        (RGBPrimaries::BT_709, WhitePoint::D65, RGBPrimaries::APPLE, WhitePoint::D65) => {
+        (RgbPrimaries::Bt709, WhitePoint::D65, RgbPrimaries::Apple, WhitePoint::D65) => {
             Some(BT_709_D65_TO_APPLE_D65)
         }
-        (RGBPrimaries::BT_709, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::D60) => {
+        (RgbPrimaries::Bt709, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::D60) => {
             Some(BT_709_D65_TO_P3_D60)
         }
-        (RGBPrimaries::BT_709, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::P3_DCI) => {
+        (RgbPrimaries::Bt709, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::P3Dci) => {
             Some(BT_709_D65_TO_P3_P3_DCI)
         }
-        (RGBPrimaries::BT_709, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::D65) => {
+        (RgbPrimaries::Bt709, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::D65) => {
             Some(BT_709_D65_TO_P3_D65)
         }
-        (RGBPrimaries::BT_709, WhitePoint::D65, RGBPrimaries::ADOBE_1998, WhitePoint::D65) => {
+        (RgbPrimaries::Bt709, WhitePoint::D65, RgbPrimaries::Adobe1998, WhitePoint::D65) => {
             Some(BT_709_D65_TO_ADOBE_1998_D65)
         }
-        (RGBPrimaries::BT_709, WhitePoint::D65, RGBPrimaries::ADOBE_WIDE, WhitePoint::D50) => {
+        (RgbPrimaries::Bt709, WhitePoint::D65, RgbPrimaries::AdobeWide, WhitePoint::D50) => {
             Some(BT_709_D65_TO_ADOBE_WIDE_D50)
         }
-        (RGBPrimaries::BT_2020, WhitePoint::D65, RGBPrimaries::BT_709, WhitePoint::D65) => {
+        (RgbPrimaries::Bt2020, WhitePoint::D65, RgbPrimaries::Bt709, WhitePoint::D65) => {
             Some(BT_2020_D65_TO_BT_709_D65)
         }
-        (RGBPrimaries::BT_2020, WhitePoint::D65, RGBPrimaries::AP1, WhitePoint::D60) => {
+        (RgbPrimaries::Bt2020, WhitePoint::D65, RgbPrimaries::Ap1, WhitePoint::D60) => {
             Some(BT_2020_D65_TO_AP1_D60)
         }
-        (RGBPrimaries::BT_2020, WhitePoint::D65, RGBPrimaries::AP0, WhitePoint::D60) => {
+        (RgbPrimaries::Bt2020, WhitePoint::D65, RgbPrimaries::Ap0, WhitePoint::D60) => {
             Some(BT_2020_D65_TO_AP0_D60)
         }
-        (RGBPrimaries::BT_2020, WhitePoint::D65, RGBPrimaries::CIE_RGB, WhitePoint::E) => {
+        (RgbPrimaries::Bt2020, WhitePoint::D65, RgbPrimaries::CieRgb, WhitePoint::E) => {
             Some(BT_2020_D65_TO_CIE_RGB_E)
         }
-        (RGBPrimaries::BT_2020, WhitePoint::D65, RGBPrimaries::CIE_XYZ, WhitePoint::D65) => {
+        (RgbPrimaries::Bt2020, WhitePoint::D65, RgbPrimaries::CieXyz, WhitePoint::D65) => {
             Some(BT_2020_D65_TO_CIE_XYZ_D65)
         }
-        (RGBPrimaries::BT_2020, WhitePoint::D65, RGBPrimaries::PRO_PHOTO, WhitePoint::D50) => {
+        (RgbPrimaries::Bt2020, WhitePoint::D65, RgbPrimaries::ProPhoto, WhitePoint::D50) => {
             Some(BT_2020_D65_TO_PRO_PHOTO_D50)
         }
-        (RGBPrimaries::BT_2020, WhitePoint::D65, RGBPrimaries::APPLE, WhitePoint::D65) => {
+        (RgbPrimaries::Bt2020, WhitePoint::D65, RgbPrimaries::Apple, WhitePoint::D65) => {
             Some(BT_2020_D65_TO_APPLE_D65)
         }
-        (RGBPrimaries::BT_2020, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::D60) => {
+        (RgbPrimaries::Bt2020, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::D60) => {
             Some(BT_2020_D65_TO_P3_D60)
         }
-        (RGBPrimaries::BT_2020, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::P3_DCI) => {
+        (RgbPrimaries::Bt2020, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::P3Dci) => {
             Some(BT_2020_D65_TO_P3_P3_DCI)
         }
-        (RGBPrimaries::BT_2020, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::D65) => {
+        (RgbPrimaries::Bt2020, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::D65) => {
             Some(BT_2020_D65_TO_P3_D65)
         }
-        (RGBPrimaries::BT_2020, WhitePoint::D65, RGBPrimaries::ADOBE_1998, WhitePoint::D65) => {
+        (RgbPrimaries::Bt2020, WhitePoint::D65, RgbPrimaries::Adobe1998, WhitePoint::D65) => {
             Some(BT_2020_D65_TO_ADOBE_1998_D65)
         }
-        (RGBPrimaries::BT_2020, WhitePoint::D65, RGBPrimaries::ADOBE_WIDE, WhitePoint::D50) => {
+        (RgbPrimaries::Bt2020, WhitePoint::D65, RgbPrimaries::AdobeWide, WhitePoint::D50) => {
             Some(BT_2020_D65_TO_ADOBE_WIDE_D50)
         }
-        (RGBPrimaries::AP1, WhitePoint::D60, RGBPrimaries::BT_709, WhitePoint::D65) => {
+        (RgbPrimaries::Ap1, WhitePoint::D60, RgbPrimaries::Bt709, WhitePoint::D65) => {
             Some(AP1_D60_TO_BT_709_D65)
         }
-        (RGBPrimaries::AP1, WhitePoint::D60, RGBPrimaries::BT_2020, WhitePoint::D65) => {
+        (RgbPrimaries::Ap1, WhitePoint::D60, RgbPrimaries::Bt2020, WhitePoint::D65) => {
             Some(AP1_D60_TO_BT_2020_D65)
         }
-        (RGBPrimaries::AP1, WhitePoint::D60, RGBPrimaries::AP0, WhitePoint::D60) => {
+        (RgbPrimaries::Ap1, WhitePoint::D60, RgbPrimaries::Ap0, WhitePoint::D60) => {
             Some(AP1_D60_TO_AP0_D60)
         }
-        (RGBPrimaries::AP1, WhitePoint::D60, RGBPrimaries::CIE_RGB, WhitePoint::E) => {
+        (RgbPrimaries::Ap1, WhitePoint::D60, RgbPrimaries::CieRgb, WhitePoint::E) => {
             Some(AP1_D60_TO_CIE_RGB_E)
         }
-        (RGBPrimaries::AP1, WhitePoint::D60, RGBPrimaries::CIE_XYZ, WhitePoint::D65) => {
+        (RgbPrimaries::Ap1, WhitePoint::D60, RgbPrimaries::CieXyz, WhitePoint::D65) => {
             Some(AP1_D60_TO_CIE_XYZ_D65)
         }
-        (RGBPrimaries::AP1, WhitePoint::D60, RGBPrimaries::PRO_PHOTO, WhitePoint::D50) => {
+        (RgbPrimaries::Ap1, WhitePoint::D60, RgbPrimaries::ProPhoto, WhitePoint::D50) => {
             Some(AP1_D60_TO_PRO_PHOTO_D50)
         }
-        (RGBPrimaries::AP1, WhitePoint::D60, RGBPrimaries::APPLE, WhitePoint::D65) => {
+        (RgbPrimaries::Ap1, WhitePoint::D60, RgbPrimaries::Apple, WhitePoint::D65) => {
             Some(AP1_D60_TO_APPLE_D65)
         }
-        (RGBPrimaries::AP1, WhitePoint::D60, RGBPrimaries::P3, WhitePoint::D60) => {
+        (RgbPrimaries::Ap1, WhitePoint::D60, RgbPrimaries::P3, WhitePoint::D60) => {
             Some(AP1_D60_TO_P3_D60)
         }
-        (RGBPrimaries::AP1, WhitePoint::D60, RGBPrimaries::P3, WhitePoint::P3_DCI) => {
+        (RgbPrimaries::Ap1, WhitePoint::D60, RgbPrimaries::P3, WhitePoint::P3Dci) => {
             Some(AP1_D60_TO_P3_P3_DCI)
         }
-        (RGBPrimaries::AP1, WhitePoint::D60, RGBPrimaries::P3, WhitePoint::D65) => {
+        (RgbPrimaries::Ap1, WhitePoint::D60, RgbPrimaries::P3, WhitePoint::D65) => {
             Some(AP1_D60_TO_P3_D65)
         }
-        (RGBPrimaries::AP1, WhitePoint::D60, RGBPrimaries::ADOBE_1998, WhitePoint::D65) => {
+        (RgbPrimaries::Ap1, WhitePoint::D60, RgbPrimaries::Adobe1998, WhitePoint::D65) => {
             Some(AP1_D60_TO_ADOBE_1998_D65)
         }
-        (RGBPrimaries::AP1, WhitePoint::D60, RGBPrimaries::ADOBE_WIDE, WhitePoint::D50) => {
+        (RgbPrimaries::Ap1, WhitePoint::D60, RgbPrimaries::AdobeWide, WhitePoint::D50) => {
             Some(AP1_D60_TO_ADOBE_WIDE_D50)
         }
-        (RGBPrimaries::AP0, WhitePoint::D60, RGBPrimaries::BT_709, WhitePoint::D65) => {
+        (RgbPrimaries::Ap0, WhitePoint::D60, RgbPrimaries::Bt709, WhitePoint::D65) => {
             Some(AP0_D60_TO_BT_709_D65)
         }
-        (RGBPrimaries::AP0, WhitePoint::D60, RGBPrimaries::BT_2020, WhitePoint::D65) => {
+        (RgbPrimaries::Ap0, WhitePoint::D60, RgbPrimaries::Bt2020, WhitePoint::D65) => {
             Some(AP0_D60_TO_BT_2020_D65)
         }
-        (RGBPrimaries::AP0, WhitePoint::D60, RGBPrimaries::AP1, WhitePoint::D60) => {
+        (RgbPrimaries::Ap0, WhitePoint::D60, RgbPrimaries::Ap1, WhitePoint::D60) => {
             Some(AP0_D60_TO_AP1_D60)
         }
-        (RGBPrimaries::AP0, WhitePoint::D60, RGBPrimaries::CIE_RGB, WhitePoint::E) => {
+        (RgbPrimaries::Ap0, WhitePoint::D60, RgbPrimaries::CieRgb, WhitePoint::E) => {
             Some(AP0_D60_TO_CIE_RGB_E)
         }
-        (RGBPrimaries::AP0, WhitePoint::D60, RGBPrimaries::CIE_XYZ, WhitePoint::D65) => {
+        (RgbPrimaries::Ap0, WhitePoint::D60, RgbPrimaries::CieXyz, WhitePoint::D65) => {
             Some(AP0_D60_TO_CIE_XYZ_D65)
         }
-        (RGBPrimaries::AP0, WhitePoint::D60, RGBPrimaries::PRO_PHOTO, WhitePoint::D50) => {
+        (RgbPrimaries::Ap0, WhitePoint::D60, RgbPrimaries::ProPhoto, WhitePoint::D50) => {
             Some(AP0_D60_TO_PRO_PHOTO_D50)
         }
-        (RGBPrimaries::AP0, WhitePoint::D60, RGBPrimaries::APPLE, WhitePoint::D65) => {
+        (RgbPrimaries::Ap0, WhitePoint::D60, RgbPrimaries::Apple, WhitePoint::D65) => {
             Some(AP0_D60_TO_APPLE_D65)
         }
-        (RGBPrimaries::AP0, WhitePoint::D60, RGBPrimaries::P3, WhitePoint::D60) => {
+        (RgbPrimaries::Ap0, WhitePoint::D60, RgbPrimaries::P3, WhitePoint::D60) => {
             Some(AP0_D60_TO_P3_D60)
         }
-        (RGBPrimaries::AP0, WhitePoint::D60, RGBPrimaries::P3, WhitePoint::P3_DCI) => {
+        (RgbPrimaries::Ap0, WhitePoint::D60, RgbPrimaries::P3, WhitePoint::P3Dci) => {
             Some(AP0_D60_TO_P3_P3_DCI)
         }
-        (RGBPrimaries::AP0, WhitePoint::D60, RGBPrimaries::P3, WhitePoint::D65) => {
+        (RgbPrimaries::Ap0, WhitePoint::D60, RgbPrimaries::P3, WhitePoint::D65) => {
             Some(AP0_D60_TO_P3_D65)
         }
-        (RGBPrimaries::AP0, WhitePoint::D60, RGBPrimaries::ADOBE_1998, WhitePoint::D65) => {
+        (RgbPrimaries::Ap0, WhitePoint::D60, RgbPrimaries::Adobe1998, WhitePoint::D65) => {
             Some(AP0_D60_TO_ADOBE_1998_D65)
         }
-        (RGBPrimaries::AP0, WhitePoint::D60, RGBPrimaries::ADOBE_WIDE, WhitePoint::D50) => {
+        (RgbPrimaries::Ap0, WhitePoint::D60, RgbPrimaries::AdobeWide, WhitePoint::D50) => {
             Some(AP0_D60_TO_ADOBE_WIDE_D50)
         }
-        (RGBPrimaries::CIE_RGB, WhitePoint::E, RGBPrimaries::BT_709, WhitePoint::D65) => {
+        (RgbPrimaries::CieRgb, WhitePoint::E, RgbPrimaries::Bt709, WhitePoint::D65) => {
             Some(CIE_RGB_E_TO_BT_709_D65)
         }
-        (RGBPrimaries::CIE_RGB, WhitePoint::E, RGBPrimaries::BT_2020, WhitePoint::D65) => {
+        (RgbPrimaries::CieRgb, WhitePoint::E, RgbPrimaries::Bt2020, WhitePoint::D65) => {
             Some(CIE_RGB_E_TO_BT_2020_D65)
         }
-        (RGBPrimaries::CIE_RGB, WhitePoint::E, RGBPrimaries::AP1, WhitePoint::D60) => {
+        (RgbPrimaries::CieRgb, WhitePoint::E, RgbPrimaries::Ap1, WhitePoint::D60) => {
             Some(CIE_RGB_E_TO_AP1_D60)
         }
-        (RGBPrimaries::CIE_RGB, WhitePoint::E, RGBPrimaries::AP0, WhitePoint::D60) => {
+        (RgbPrimaries::CieRgb, WhitePoint::E, RgbPrimaries::Ap0, WhitePoint::D60) => {
             Some(CIE_RGB_E_TO_AP0_D60)
         }
-        (RGBPrimaries::CIE_RGB, WhitePoint::E, RGBPrimaries::CIE_XYZ, WhitePoint::D65) => {
+        (RgbPrimaries::CieRgb, WhitePoint::E, RgbPrimaries::CieXyz, WhitePoint::D65) => {
             Some(CIE_RGB_E_TO_CIE_XYZ_D65)
         }
-        (RGBPrimaries::CIE_RGB, WhitePoint::E, RGBPrimaries::PRO_PHOTO, WhitePoint::D50) => {
+        (RgbPrimaries::CieRgb, WhitePoint::E, RgbPrimaries::ProPhoto, WhitePoint::D50) => {
             Some(CIE_RGB_E_TO_PRO_PHOTO_D50)
         }
-        (RGBPrimaries::CIE_RGB, WhitePoint::E, RGBPrimaries::APPLE, WhitePoint::D65) => {
+        (RgbPrimaries::CieRgb, WhitePoint::E, RgbPrimaries::Apple, WhitePoint::D65) => {
             Some(CIE_RGB_E_TO_APPLE_D65)
         }
-        (RGBPrimaries::CIE_RGB, WhitePoint::E, RGBPrimaries::P3, WhitePoint::D60) => {
+        (RgbPrimaries::CieRgb, WhitePoint::E, RgbPrimaries::P3, WhitePoint::D60) => {
             Some(CIE_RGB_E_TO_P3_D60)
         }
-        (RGBPrimaries::CIE_RGB, WhitePoint::E, RGBPrimaries::P3, WhitePoint::P3_DCI) => {
+        (RgbPrimaries::CieRgb, WhitePoint::E, RgbPrimaries::P3, WhitePoint::P3Dci) => {
             Some(CIE_RGB_E_TO_P3_P3_DCI)
         }
-        (RGBPrimaries::CIE_RGB, WhitePoint::E, RGBPrimaries::P3, WhitePoint::D65) => {
+        (RgbPrimaries::CieRgb, WhitePoint::E, RgbPrimaries::P3, WhitePoint::D65) => {
             Some(CIE_RGB_E_TO_P3_D65)
         }
-        (RGBPrimaries::CIE_RGB, WhitePoint::E, RGBPrimaries::ADOBE_1998, WhitePoint::D65) => {
+        (RgbPrimaries::CieRgb, WhitePoint::E, RgbPrimaries::Adobe1998, WhitePoint::D65) => {
             Some(CIE_RGB_E_TO_ADOBE_1998_D65)
         }
-        (RGBPrimaries::CIE_RGB, WhitePoint::E, RGBPrimaries::ADOBE_WIDE, WhitePoint::D50) => {
+        (RgbPrimaries::CieRgb, WhitePoint::E, RgbPrimaries::AdobeWide, WhitePoint::D50) => {
             Some(CIE_RGB_E_TO_ADOBE_WIDE_D50)
         }
-        (RGBPrimaries::CIE_XYZ, WhitePoint::D65, RGBPrimaries::BT_709, WhitePoint::D65) => {
+        (RgbPrimaries::CieXyz, WhitePoint::D65, RgbPrimaries::Bt709, WhitePoint::D65) => {
             Some(CIE_XYZ_D65_TO_BT_709_D65)
         }
-        (RGBPrimaries::CIE_XYZ, WhitePoint::D65, RGBPrimaries::BT_2020, WhitePoint::D65) => {
+        (RgbPrimaries::CieXyz, WhitePoint::D65, RgbPrimaries::Bt2020, WhitePoint::D65) => {
             Some(CIE_XYZ_D65_TO_BT_2020_D65)
         }
-        (RGBPrimaries::CIE_XYZ, WhitePoint::D65, RGBPrimaries::AP1, WhitePoint::D60) => {
+        (RgbPrimaries::CieXyz, WhitePoint::D65, RgbPrimaries::Ap1, WhitePoint::D60) => {
             Some(CIE_XYZ_D65_TO_AP1_D60)
         }
-        (RGBPrimaries::CIE_XYZ, WhitePoint::D65, RGBPrimaries::AP0, WhitePoint::D60) => {
+        (RgbPrimaries::CieXyz, WhitePoint::D65, RgbPrimaries::Ap0, WhitePoint::D60) => {
             Some(CIE_XYZ_D65_TO_AP0_D60)
         }
-        (RGBPrimaries::CIE_XYZ, WhitePoint::D65, RGBPrimaries::CIE_RGB, WhitePoint::E) => {
+        (RgbPrimaries::CieXyz, WhitePoint::D65, RgbPrimaries::CieRgb, WhitePoint::E) => {
             Some(CIE_XYZ_D65_TO_CIE_RGB_E)
         }
-        (RGBPrimaries::CIE_XYZ, WhitePoint::D65, RGBPrimaries::PRO_PHOTO, WhitePoint::D50) => {
+        (RgbPrimaries::CieXyz, WhitePoint::D65, RgbPrimaries::ProPhoto, WhitePoint::D50) => {
             Some(CIE_XYZ_D65_TO_PRO_PHOTO_D50)
         }
-        (RGBPrimaries::CIE_XYZ, WhitePoint::D65, RGBPrimaries::APPLE, WhitePoint::D65) => {
+        (RgbPrimaries::CieXyz, WhitePoint::D65, RgbPrimaries::Apple, WhitePoint::D65) => {
             Some(CIE_XYZ_D65_TO_APPLE_D65)
         }
-        (RGBPrimaries::CIE_XYZ, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::D60) => {
+        (RgbPrimaries::CieXyz, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::D60) => {
             Some(CIE_XYZ_D65_TO_P3_D60)
         }
-        (RGBPrimaries::CIE_XYZ, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::P3_DCI) => {
+        (RgbPrimaries::CieXyz, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::P3Dci) => {
             Some(CIE_XYZ_D65_TO_P3_P3_DCI)
         }
-        (RGBPrimaries::CIE_XYZ, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::D65) => {
+        (RgbPrimaries::CieXyz, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::D65) => {
             Some(CIE_XYZ_D65_TO_P3_D65)
         }
-        (RGBPrimaries::CIE_XYZ, WhitePoint::D65, RGBPrimaries::ADOBE_1998, WhitePoint::D65) => {
+        (RgbPrimaries::CieXyz, WhitePoint::D65, RgbPrimaries::Adobe1998, WhitePoint::D65) => {
             Some(CIE_XYZ_D65_TO_ADOBE_1998_D65)
         }
-        (RGBPrimaries::CIE_XYZ, WhitePoint::D65, RGBPrimaries::ADOBE_WIDE, WhitePoint::D50) => {
+        (RgbPrimaries::CieXyz, WhitePoint::D65, RgbPrimaries::AdobeWide, WhitePoint::D50) => {
             Some(CIE_XYZ_D65_TO_ADOBE_WIDE_D50)
         }
-        (RGBPrimaries::PRO_PHOTO, WhitePoint::D50, RGBPrimaries::BT_709, WhitePoint::D65) => {
+        (RgbPrimaries::ProPhoto, WhitePoint::D50, RgbPrimaries::Bt709, WhitePoint::D65) => {
             Some(PRO_PHOTO_D50_TO_BT_709_D65)
         }
-        (RGBPrimaries::PRO_PHOTO, WhitePoint::D50, RGBPrimaries::BT_2020, WhitePoint::D65) => {
+        (RgbPrimaries::ProPhoto, WhitePoint::D50, RgbPrimaries::Bt2020, WhitePoint::D65) => {
             Some(PRO_PHOTO_D50_TO_BT_2020_D65)
         }
-        (RGBPrimaries::PRO_PHOTO, WhitePoint::D50, RGBPrimaries::AP1, WhitePoint::D60) => {
+        (RgbPrimaries::ProPhoto, WhitePoint::D50, RgbPrimaries::Ap1, WhitePoint::D60) => {
             Some(PRO_PHOTO_D50_TO_AP1_D60)
         }
-        (RGBPrimaries::PRO_PHOTO, WhitePoint::D50, RGBPrimaries::AP0, WhitePoint::D60) => {
+        (RgbPrimaries::ProPhoto, WhitePoint::D50, RgbPrimaries::Ap0, WhitePoint::D60) => {
             Some(PRO_PHOTO_D50_TO_AP0_D60)
         }
-        (RGBPrimaries::PRO_PHOTO, WhitePoint::D50, RGBPrimaries::CIE_RGB, WhitePoint::E) => {
+        (RgbPrimaries::ProPhoto, WhitePoint::D50, RgbPrimaries::CieRgb, WhitePoint::E) => {
             Some(PRO_PHOTO_D50_TO_CIE_RGB_E)
         }
-        (RGBPrimaries::PRO_PHOTO, WhitePoint::D50, RGBPrimaries::CIE_XYZ, WhitePoint::D65) => {
+        (RgbPrimaries::ProPhoto, WhitePoint::D50, RgbPrimaries::CieXyz, WhitePoint::D65) => {
             Some(PRO_PHOTO_D50_TO_CIE_XYZ_D65)
         }
-        (RGBPrimaries::PRO_PHOTO, WhitePoint::D50, RGBPrimaries::APPLE, WhitePoint::D65) => {
+        (RgbPrimaries::ProPhoto, WhitePoint::D50, RgbPrimaries::Apple, WhitePoint::D65) => {
             Some(PRO_PHOTO_D50_TO_APPLE_D65)
         }
-        (RGBPrimaries::PRO_PHOTO, WhitePoint::D50, RGBPrimaries::P3, WhitePoint::D60) => {
+        (RgbPrimaries::ProPhoto, WhitePoint::D50, RgbPrimaries::P3, WhitePoint::D60) => {
             Some(PRO_PHOTO_D50_TO_P3_D60)
         }
-        (RGBPrimaries::PRO_PHOTO, WhitePoint::D50, RGBPrimaries::P3, WhitePoint::P3_DCI) => {
+        (RgbPrimaries::ProPhoto, WhitePoint::D50, RgbPrimaries::P3, WhitePoint::P3Dci) => {
             Some(PRO_PHOTO_D50_TO_P3_P3_DCI)
         }
-        (RGBPrimaries::PRO_PHOTO, WhitePoint::D50, RGBPrimaries::P3, WhitePoint::D65) => {
+        (RgbPrimaries::ProPhoto, WhitePoint::D50, RgbPrimaries::P3, WhitePoint::D65) => {
             Some(PRO_PHOTO_D50_TO_P3_D65)
         }
-        (RGBPrimaries::PRO_PHOTO, WhitePoint::D50, RGBPrimaries::ADOBE_1998, WhitePoint::D65) => {
+        (RgbPrimaries::ProPhoto, WhitePoint::D50, RgbPrimaries::Adobe1998, WhitePoint::D65) => {
             Some(PRO_PHOTO_D50_TO_ADOBE_1998_D65)
         }
-        (RGBPrimaries::PRO_PHOTO, WhitePoint::D50, RGBPrimaries::ADOBE_WIDE, WhitePoint::D50) => {
+        (RgbPrimaries::ProPhoto, WhitePoint::D50, RgbPrimaries::AdobeWide, WhitePoint::D50) => {
             Some(PRO_PHOTO_D50_TO_ADOBE_WIDE_D50)
         }
-        (RGBPrimaries::APPLE, WhitePoint::D65, RGBPrimaries::BT_709, WhitePoint::D65) => {
+        (RgbPrimaries::Apple, WhitePoint::D65, RgbPrimaries::Bt709, WhitePoint::D65) => {
             Some(APPLE_D65_TO_BT_709_D65)
         }
-        (RGBPrimaries::APPLE, WhitePoint::D65, RGBPrimaries::BT_2020, WhitePoint::D65) => {
+        (RgbPrimaries::Apple, WhitePoint::D65, RgbPrimaries::Bt2020, WhitePoint::D65) => {
             Some(APPLE_D65_TO_BT_2020_D65)
         }
-        (RGBPrimaries::APPLE, WhitePoint::D65, RGBPrimaries::AP1, WhitePoint::D60) => {
+        (RgbPrimaries::Apple, WhitePoint::D65, RgbPrimaries::Ap1, WhitePoint::D60) => {
             Some(APPLE_D65_TO_AP1_D60)
         }
-        (RGBPrimaries::APPLE, WhitePoint::D65, RGBPrimaries::AP0, WhitePoint::D60) => {
+        (RgbPrimaries::Apple, WhitePoint::D65, RgbPrimaries::Ap0, WhitePoint::D60) => {
             Some(APPLE_D65_TO_AP0_D60)
         }
-        (RGBPrimaries::APPLE, WhitePoint::D65, RGBPrimaries::CIE_RGB, WhitePoint::E) => {
+        (RgbPrimaries::Apple, WhitePoint::D65, RgbPrimaries::CieRgb, WhitePoint::E) => {
             Some(APPLE_D65_TO_CIE_RGB_E)
         }
-        (RGBPrimaries::APPLE, WhitePoint::D65, RGBPrimaries::CIE_XYZ, WhitePoint::D65) => {
+        (RgbPrimaries::Apple, WhitePoint::D65, RgbPrimaries::CieXyz, WhitePoint::D65) => {
             Some(APPLE_D65_TO_CIE_XYZ_D65)
         }
-        (RGBPrimaries::APPLE, WhitePoint::D65, RGBPrimaries::PRO_PHOTO, WhitePoint::D50) => {
+        (RgbPrimaries::Apple, WhitePoint::D65, RgbPrimaries::ProPhoto, WhitePoint::D50) => {
             Some(APPLE_D65_TO_PRO_PHOTO_D50)
         }
-        (RGBPrimaries::APPLE, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::D60) => {
+        (RgbPrimaries::Apple, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::D60) => {
             Some(APPLE_D65_TO_P3_D60)
         }
-        (RGBPrimaries::APPLE, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::P3_DCI) => {
+        (RgbPrimaries::Apple, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::P3Dci) => {
             Some(APPLE_D65_TO_P3_P3_DCI)
         }
-        (RGBPrimaries::APPLE, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::D65) => {
+        (RgbPrimaries::Apple, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::D65) => {
             Some(APPLE_D65_TO_P3_D65)
         }
-        (RGBPrimaries::APPLE, WhitePoint::D65, RGBPrimaries::ADOBE_1998, WhitePoint::D65) => {
+        (RgbPrimaries::Apple, WhitePoint::D65, RgbPrimaries::Adobe1998, WhitePoint::D65) => {
             Some(APPLE_D65_TO_ADOBE_1998_D65)
         }
-        (RGBPrimaries::APPLE, WhitePoint::D65, RGBPrimaries::ADOBE_WIDE, WhitePoint::D50) => {
+        (RgbPrimaries::Apple, WhitePoint::D65, RgbPrimaries::AdobeWide, WhitePoint::D50) => {
             Some(APPLE_D65_TO_ADOBE_WIDE_D50)
         }
-        (RGBPrimaries::P3, WhitePoint::D60, RGBPrimaries::BT_709, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::D60, RgbPrimaries::Bt709, WhitePoint::D65) => {
             Some(P3_D60_TO_BT_709_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::D60, RGBPrimaries::BT_2020, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::D60, RgbPrimaries::Bt2020, WhitePoint::D65) => {
             Some(P3_D60_TO_BT_2020_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::D60, RGBPrimaries::AP1, WhitePoint::D60) => {
+        (RgbPrimaries::P3, WhitePoint::D60, RgbPrimaries::Ap1, WhitePoint::D60) => {
             Some(P3_D60_TO_AP1_D60)
         }
-        (RGBPrimaries::P3, WhitePoint::D60, RGBPrimaries::AP0, WhitePoint::D60) => {
+        (RgbPrimaries::P3, WhitePoint::D60, RgbPrimaries::Ap0, WhitePoint::D60) => {
             Some(P3_D60_TO_AP0_D60)
         }
-        (RGBPrimaries::P3, WhitePoint::D60, RGBPrimaries::CIE_RGB, WhitePoint::E) => {
+        (RgbPrimaries::P3, WhitePoint::D60, RgbPrimaries::CieRgb, WhitePoint::E) => {
             Some(P3_D60_TO_CIE_RGB_E)
         }
-        (RGBPrimaries::P3, WhitePoint::D60, RGBPrimaries::CIE_XYZ, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::D60, RgbPrimaries::CieXyz, WhitePoint::D65) => {
             Some(P3_D60_TO_CIE_XYZ_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::D60, RGBPrimaries::PRO_PHOTO, WhitePoint::D50) => {
+        (RgbPrimaries::P3, WhitePoint::D60, RgbPrimaries::ProPhoto, WhitePoint::D50) => {
             Some(P3_D60_TO_PRO_PHOTO_D50)
         }
-        (RGBPrimaries::P3, WhitePoint::D60, RGBPrimaries::APPLE, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::D60, RgbPrimaries::Apple, WhitePoint::D65) => {
             Some(P3_D60_TO_APPLE_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::D60, RGBPrimaries::P3, WhitePoint::P3_DCI) => {
+        (RgbPrimaries::P3, WhitePoint::D60, RgbPrimaries::P3, WhitePoint::P3Dci) => {
             Some(P3_D60_TO_P3_P3_DCI)
         }
-        (RGBPrimaries::P3, WhitePoint::D60, RGBPrimaries::P3, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::D60, RgbPrimaries::P3, WhitePoint::D65) => {
             Some(P3_D60_TO_P3_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::D60, RGBPrimaries::ADOBE_1998, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::D60, RgbPrimaries::Adobe1998, WhitePoint::D65) => {
             Some(P3_D60_TO_ADOBE_1998_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::D60, RGBPrimaries::ADOBE_WIDE, WhitePoint::D50) => {
+        (RgbPrimaries::P3, WhitePoint::D60, RgbPrimaries::AdobeWide, WhitePoint::D50) => {
             Some(P3_D60_TO_ADOBE_WIDE_D50)
         }
-        (RGBPrimaries::P3, WhitePoint::P3_DCI, RGBPrimaries::BT_709, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::P3Dci, RgbPrimaries::Bt709, WhitePoint::D65) => {
             Some(P3_P3_DCI_TO_BT_709_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::P3_DCI, RGBPrimaries::BT_2020, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::P3Dci, RgbPrimaries::Bt2020, WhitePoint::D65) => {
             Some(P3_P3_DCI_TO_BT_2020_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::P3_DCI, RGBPrimaries::AP1, WhitePoint::D60) => {
+        (RgbPrimaries::P3, WhitePoint::P3Dci, RgbPrimaries::Ap1, WhitePoint::D60) => {
             Some(P3_P3_DCI_TO_AP1_D60)
         }
-        (RGBPrimaries::P3, WhitePoint::P3_DCI, RGBPrimaries::AP0, WhitePoint::D60) => {
+        (RgbPrimaries::P3, WhitePoint::P3Dci, RgbPrimaries::Ap0, WhitePoint::D60) => {
             Some(P3_P3_DCI_TO_AP0_D60)
         }
-        (RGBPrimaries::P3, WhitePoint::P3_DCI, RGBPrimaries::CIE_RGB, WhitePoint::E) => {
+        (RgbPrimaries::P3, WhitePoint::P3Dci, RgbPrimaries::CieRgb, WhitePoint::E) => {
             Some(P3_P3_DCI_TO_CIE_RGB_E)
         }
-        (RGBPrimaries::P3, WhitePoint::P3_DCI, RGBPrimaries::CIE_XYZ, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::P3Dci, RgbPrimaries::CieXyz, WhitePoint::D65) => {
             Some(P3_P3_DCI_TO_CIE_XYZ_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::P3_DCI, RGBPrimaries::PRO_PHOTO, WhitePoint::D50) => {
+        (RgbPrimaries::P3, WhitePoint::P3Dci, RgbPrimaries::ProPhoto, WhitePoint::D50) => {
             Some(P3_P3_DCI_TO_PRO_PHOTO_D50)
         }
-        (RGBPrimaries::P3, WhitePoint::P3_DCI, RGBPrimaries::APPLE, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::P3Dci, RgbPrimaries::Apple, WhitePoint::D65) => {
             Some(P3_P3_DCI_TO_APPLE_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::P3_DCI, RGBPrimaries::P3, WhitePoint::D60) => {
+        (RgbPrimaries::P3, WhitePoint::P3Dci, RgbPrimaries::P3, WhitePoint::D60) => {
             Some(P3_P3_DCI_TO_P3_D60)
         }
-        (RGBPrimaries::P3, WhitePoint::P3_DCI, RGBPrimaries::P3, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::P3Dci, RgbPrimaries::P3, WhitePoint::D65) => {
             Some(P3_P3_DCI_TO_P3_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::P3_DCI, RGBPrimaries::ADOBE_1998, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::P3Dci, RgbPrimaries::Adobe1998, WhitePoint::D65) => {
             Some(P3_P3_DCI_TO_ADOBE_1998_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::P3_DCI, RGBPrimaries::ADOBE_WIDE, WhitePoint::D50) => {
+        (RgbPrimaries::P3, WhitePoint::P3Dci, RgbPrimaries::AdobeWide, WhitePoint::D50) => {
             Some(P3_P3_DCI_TO_ADOBE_WIDE_D50)
         }
-        (RGBPrimaries::P3, WhitePoint::D65, RGBPrimaries::BT_709, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::D65, RgbPrimaries::Bt709, WhitePoint::D65) => {
             Some(P3_D65_TO_BT_709_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::D65, RGBPrimaries::BT_2020, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::D65, RgbPrimaries::Bt2020, WhitePoint::D65) => {
             Some(P3_D65_TO_BT_2020_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::D65, RGBPrimaries::AP1, WhitePoint::D60) => {
+        (RgbPrimaries::P3, WhitePoint::D65, RgbPrimaries::Ap1, WhitePoint::D60) => {
             Some(P3_D65_TO_AP1_D60)
         }
-        (RGBPrimaries::P3, WhitePoint::D65, RGBPrimaries::AP0, WhitePoint::D60) => {
+        (RgbPrimaries::P3, WhitePoint::D65, RgbPrimaries::Ap0, WhitePoint::D60) => {
             Some(P3_D65_TO_AP0_D60)
         }
-        (RGBPrimaries::P3, WhitePoint::D65, RGBPrimaries::CIE_RGB, WhitePoint::E) => {
+        (RgbPrimaries::P3, WhitePoint::D65, RgbPrimaries::CieRgb, WhitePoint::E) => {
             Some(P3_D65_TO_CIE_RGB_E)
         }
-        (RGBPrimaries::P3, WhitePoint::D65, RGBPrimaries::CIE_XYZ, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::D65, RgbPrimaries::CieXyz, WhitePoint::D65) => {
             Some(P3_D65_TO_CIE_XYZ_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::D65, RGBPrimaries::PRO_PHOTO, WhitePoint::D50) => {
+        (RgbPrimaries::P3, WhitePoint::D65, RgbPrimaries::ProPhoto, WhitePoint::D50) => {
             Some(P3_D65_TO_PRO_PHOTO_D50)
         }
-        (RGBPrimaries::P3, WhitePoint::D65, RGBPrimaries::APPLE, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::D65, RgbPrimaries::Apple, WhitePoint::D65) => {
             Some(P3_D65_TO_APPLE_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::D60) => {
+        (RgbPrimaries::P3, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::D60) => {
             Some(P3_D65_TO_P3_D60)
         }
-        (RGBPrimaries::P3, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::P3_DCI) => {
+        (RgbPrimaries::P3, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::P3Dci) => {
             Some(P3_D65_TO_P3_P3_DCI)
         }
-        (RGBPrimaries::P3, WhitePoint::D65, RGBPrimaries::ADOBE_1998, WhitePoint::D65) => {
+        (RgbPrimaries::P3, WhitePoint::D65, RgbPrimaries::Adobe1998, WhitePoint::D65) => {
             Some(P3_D65_TO_ADOBE_1998_D65)
         }
-        (RGBPrimaries::P3, WhitePoint::D65, RGBPrimaries::ADOBE_WIDE, WhitePoint::D50) => {
+        (RgbPrimaries::P3, WhitePoint::D65, RgbPrimaries::AdobeWide, WhitePoint::D50) => {
             Some(P3_D65_TO_ADOBE_WIDE_D50)
         }
-        (RGBPrimaries::ADOBE_1998, WhitePoint::D65, RGBPrimaries::BT_709, WhitePoint::D65) => {
+        (RgbPrimaries::Adobe1998, WhitePoint::D65, RgbPrimaries::Bt709, WhitePoint::D65) => {
             Some(ADOBE_1998_D65_TO_BT_709_D65)
         }
-        (RGBPrimaries::ADOBE_1998, WhitePoint::D65, RGBPrimaries::BT_2020, WhitePoint::D65) => {
+        (RgbPrimaries::Adobe1998, WhitePoint::D65, RgbPrimaries::Bt2020, WhitePoint::D65) => {
             Some(ADOBE_1998_D65_TO_BT_2020_D65)
         }
-        (RGBPrimaries::ADOBE_1998, WhitePoint::D65, RGBPrimaries::AP1, WhitePoint::D60) => {
+        (RgbPrimaries::Adobe1998, WhitePoint::D65, RgbPrimaries::Ap1, WhitePoint::D60) => {
             Some(ADOBE_1998_D65_TO_AP1_D60)
         }
-        (RGBPrimaries::ADOBE_1998, WhitePoint::D65, RGBPrimaries::AP0, WhitePoint::D60) => {
+        (RgbPrimaries::Adobe1998, WhitePoint::D65, RgbPrimaries::Ap0, WhitePoint::D60) => {
             Some(ADOBE_1998_D65_TO_AP0_D60)
         }
-        (RGBPrimaries::ADOBE_1998, WhitePoint::D65, RGBPrimaries::CIE_RGB, WhitePoint::E) => {
+        (RgbPrimaries::Adobe1998, WhitePoint::D65, RgbPrimaries::CieRgb, WhitePoint::E) => {
             Some(ADOBE_1998_D65_TO_CIE_RGB_E)
         }
-        (RGBPrimaries::ADOBE_1998, WhitePoint::D65, RGBPrimaries::CIE_XYZ, WhitePoint::D65) => {
+        (RgbPrimaries::Adobe1998, WhitePoint::D65, RgbPrimaries::CieXyz, WhitePoint::D65) => {
             Some(ADOBE_1998_D65_TO_CIE_XYZ_D65)
         }
-        (RGBPrimaries::ADOBE_1998, WhitePoint::D65, RGBPrimaries::PRO_PHOTO, WhitePoint::D50) => {
+        (RgbPrimaries::Adobe1998, WhitePoint::D65, RgbPrimaries::ProPhoto, WhitePoint::D50) => {
             Some(ADOBE_1998_D65_TO_PRO_PHOTO_D50)
         }
-        (RGBPrimaries::ADOBE_1998, WhitePoint::D65, RGBPrimaries::APPLE, WhitePoint::D65) => {
+        (RgbPrimaries::Adobe1998, WhitePoint::D65, RgbPrimaries::Apple, WhitePoint::D65) => {
             Some(ADOBE_1998_D65_TO_APPLE_D65)
         }
-        (RGBPrimaries::ADOBE_1998, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::D60) => {
+        (RgbPrimaries::Adobe1998, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::D60) => {
             Some(ADOBE_1998_D65_TO_P3_D60)
         }
-        (RGBPrimaries::ADOBE_1998, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::P3_DCI) => {
+        (RgbPrimaries::Adobe1998, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::P3Dci) => {
             Some(ADOBE_1998_D65_TO_P3_P3_DCI)
         }
-        (RGBPrimaries::ADOBE_1998, WhitePoint::D65, RGBPrimaries::P3, WhitePoint::D65) => {
+        (RgbPrimaries::Adobe1998, WhitePoint::D65, RgbPrimaries::P3, WhitePoint::D65) => {
             Some(ADOBE_1998_D65_TO_P3_D65)
         }
-        (RGBPrimaries::ADOBE_1998, WhitePoint::D65, RGBPrimaries::ADOBE_WIDE, WhitePoint::D50) => {
+        (RgbPrimaries::Adobe1998, WhitePoint::D65, RgbPrimaries::AdobeWide, WhitePoint::D50) => {
             Some(ADOBE_1998_D65_TO_ADOBE_WIDE_D50)
         }
-        (RGBPrimaries::ADOBE_WIDE, WhitePoint::D50, RGBPrimaries::BT_709, WhitePoint::D65) => {
+        (RgbPrimaries::AdobeWide, WhitePoint::D50, RgbPrimaries::Bt709, WhitePoint::D65) => {
             Some(ADOBE_WIDE_D50_TO_BT_709_D65)
         }
-        (RGBPrimaries::ADOBE_WIDE, WhitePoint::D50, RGBPrimaries::BT_2020, WhitePoint::D65) => {
+        (RgbPrimaries::AdobeWide, WhitePoint::D50, RgbPrimaries::Bt2020, WhitePoint::D65) => {
             Some(ADOBE_WIDE_D50_TO_BT_2020_D65)
         }
-        (RGBPrimaries::ADOBE_WIDE, WhitePoint::D50, RGBPrimaries::AP1, WhitePoint::D60) => {
+        (RgbPrimaries::AdobeWide, WhitePoint::D50, RgbPrimaries::Ap1, WhitePoint::D60) => {
             Some(ADOBE_WIDE_D50_TO_AP1_D60)
         }
-        (RGBPrimaries::ADOBE_WIDE, WhitePoint::D50, RGBPrimaries::AP0, WhitePoint::D60) => {
+        (RgbPrimaries::AdobeWide, WhitePoint::D50, RgbPrimaries::Ap0, WhitePoint::D60) => {
             Some(ADOBE_WIDE_D50_TO_AP0_D60)
         }
-        (RGBPrimaries::ADOBE_WIDE, WhitePoint::D50, RGBPrimaries::CIE_RGB, WhitePoint::E) => {
+        (RgbPrimaries::AdobeWide, WhitePoint::D50, RgbPrimaries::CieRgb, WhitePoint::E) => {
             Some(ADOBE_WIDE_D50_TO_CIE_RGB_E)
         }
-        (RGBPrimaries::ADOBE_WIDE, WhitePoint::D50, RGBPrimaries::CIE_XYZ, WhitePoint::D65) => {
+        (RgbPrimaries::AdobeWide, WhitePoint::D50, RgbPrimaries::CieXyz, WhitePoint::D65) => {
             Some(ADOBE_WIDE_D50_TO_CIE_XYZ_D65)
         }
-        (RGBPrimaries::ADOBE_WIDE, WhitePoint::D50, RGBPrimaries::PRO_PHOTO, WhitePoint::D50) => {
+        (RgbPrimaries::AdobeWide, WhitePoint::D50, RgbPrimaries::ProPhoto, WhitePoint::D50) => {
             Some(ADOBE_WIDE_D50_TO_PRO_PHOTO_D50)
         }
-        (RGBPrimaries::ADOBE_WIDE, WhitePoint::D50, RGBPrimaries::APPLE, WhitePoint::D65) => {
+        (RgbPrimaries::AdobeWide, WhitePoint::D50, RgbPrimaries::Apple, WhitePoint::D65) => {
             Some(ADOBE_WIDE_D50_TO_APPLE_D65)
         }
-        (RGBPrimaries::ADOBE_WIDE, WhitePoint::D50, RGBPrimaries::P3, WhitePoint::D60) => {
+        (RgbPrimaries::AdobeWide, WhitePoint::D50, RgbPrimaries::P3, WhitePoint::D60) => {
             Some(ADOBE_WIDE_D50_TO_P3_D60)
         }
-        (RGBPrimaries::ADOBE_WIDE, WhitePoint::D50, RGBPrimaries::P3, WhitePoint::P3_DCI) => {
+        (RgbPrimaries::AdobeWide, WhitePoint::D50, RgbPrimaries::P3, WhitePoint::P3Dci) => {
             Some(ADOBE_WIDE_D50_TO_P3_P3_DCI)
         }
-        (RGBPrimaries::ADOBE_WIDE, WhitePoint::D50, RGBPrimaries::P3, WhitePoint::D65) => {
+        (RgbPrimaries::AdobeWide, WhitePoint::D50, RgbPrimaries::P3, WhitePoint::D65) => {
             Some(ADOBE_WIDE_D50_TO_P3_D65)
         }
-        (RGBPrimaries::ADOBE_WIDE, WhitePoint::D50, RGBPrimaries::ADOBE_1998, WhitePoint::D65) => {
+        (RgbPrimaries::AdobeWide, WhitePoint::D50, RgbPrimaries::Adobe1998, WhitePoint::D65) => {
             Some(ADOBE_WIDE_D50_TO_ADOBE_1998_D65)
         }
         _ => None,

--- a/kolor/src/details/math.rs
+++ b/kolor/src/details/math.rs
@@ -38,7 +38,7 @@ mod math {
 #[cfg(not(feature = "glam"))]
 #[allow(clippy::module_inception)]
 mod math {
-    use crate::FType;
+    use crate::Float;
     #[cfg(all(not(feature = "std"), feature = "libm"))]
     use core::ops::{Add, Div, Mul, MulAssign, Sub};
     #[cfg(all(not(feature = "std"), feature = "libm"))]
@@ -46,12 +46,12 @@ mod math {
     #[cfg(all(not(feature = "libm"), feature = "std"))]
     use std::ops::{Add, Div, Mul, MulAssign, Sub};
 
-    #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[derive(Debug, Clone, Copy, PartialEq)]
     pub struct Vec3 {
-        pub x: FType,
-        pub y: FType,
-        pub z: FType,
+        pub x: Float,
+        pub y: Float,
+        pub z: Float,
     }
 
     pub struct BVec3 {
@@ -61,11 +61,11 @@ mod math {
     }
 
     impl Vec3 {
-        pub const fn new(x: FType, y: FType, z: FType) -> Self {
+        pub const fn new(x: Float, y: Float, z: Float) -> Self {
             Self { x, y, z }
         }
 
-        pub const fn splat(value: FType) -> Self {
+        pub const fn splat(value: Float) -> Self {
             Self {
                 x: value,
                 y: value,
@@ -73,7 +73,7 @@ mod math {
             }
         }
 
-        pub const fn from_slice(slice: &[FType]) -> Self {
+        pub const fn from_slice(slice: &[Float]) -> Self {
             Self {
                 x: slice[0],
                 y: slice[1],
@@ -81,7 +81,7 @@ mod math {
             }
         }
 
-        pub fn powf(self, n: FType) -> Self {
+        pub fn powf(self, n: Float) -> Self {
             Self {
                 x: self.x.powf(n),
                 y: self.y.powf(n),
@@ -112,11 +112,11 @@ mod math {
             }
         }
 
-        pub fn dot(self, other: Self) -> FType {
+        pub fn dot(self, other: Self) -> Float {
             self.x * other.x + self.y * other.y + self.z * other.z
         }
 
-        pub fn abs_diff_eq(self, other: Self, max_abs_diff: FType) -> bool {
+        pub fn abs_diff_eq(self, other: Self, max_abs_diff: Float) -> bool {
             (self.x - other.x).abs() <= max_abs_diff
                 && (self.y - other.y).abs() <= max_abs_diff
                 && (self.z - other.z).abs() <= max_abs_diff
@@ -166,16 +166,16 @@ mod math {
         }
     }
 
-    impl MulAssign<FType> for Vec3 {
-        fn mul_assign(&mut self, other: FType) {
+    impl MulAssign<Float> for Vec3 {
+        fn mul_assign(&mut self, other: Float) {
             *self = *self * other
         }
     }
 
-    impl Mul<FType> for Vec3 {
+    impl Mul<Float> for Vec3 {
         type Output = Self;
 
-        fn mul(self, other: FType) -> Self {
+        fn mul(self, other: Float) -> Self {
             Self {
                 x: self.x * other,
                 y: self.y * other,
@@ -184,7 +184,7 @@ mod math {
         }
     }
 
-    impl Mul<Vec3> for FType {
+    impl Mul<Vec3> for Float {
         type Output = Vec3;
 
         fn mul(self, other: Vec3) -> Vec3 {
@@ -192,10 +192,10 @@ mod math {
         }
     }
 
-    impl Div<FType> for Vec3 {
+    impl Div<Float> for Vec3 {
         type Output = Self;
 
-        fn div(self, other: FType) -> Self {
+        fn div(self, other: Float) -> Self {
             Self {
                 x: self.x / other,
                 y: self.y / other,
@@ -206,17 +206,17 @@ mod math {
 
     #[derive(Debug, Clone, Copy, PartialEq)]
     pub struct Vec2 {
-        pub x: FType,
-        pub y: FType,
+        pub x: Float,
+        pub y: Float,
     }
 
     impl Vec2 {
-        pub fn length(self) -> FType {
+        pub fn length(self) -> Float {
             (self.x * self.x + self.y * self.y).sqrt()
         }
     }
 
-    #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[derive(Debug, Clone, Copy, PartialEq)]
     pub struct Mat3 {
         pub x_axis: Vec3,
@@ -231,7 +231,7 @@ mod math {
             z_axis: Vec3::new(0.0, 0.0, 1.0),
         };
 
-        pub const fn from_cols_array(m: &[FType; 9]) -> Self {
+        pub const fn from_cols_array(m: &[Float; 9]) -> Self {
             Self {
                 x_axis: Vec3::new(m[0], m[1], m[2]),
                 y_axis: Vec3::new(m[3], m[4], m[5]),
@@ -289,6 +289,7 @@ mod math {
 
     impl Mul<Vec3> for Mat3 {
         type Output = Vec3;
+
         #[inline]
         fn mul(self, other: Vec3) -> Vec3 {
             let r0 = Vec3::new(self.x_axis.x, self.y_axis.x, self.z_axis.x);
@@ -301,6 +302,7 @@ mod math {
 
     impl Mul<Mat3> for Mat3 {
         type Output = Mat3;
+
         #[inline]
         fn mul(self, other: Self) -> Self {
             let r0 = Vec3::new(self.x_axis.x, self.y_axis.x, self.z_axis.x);
@@ -327,8 +329,8 @@ mod math {
         }
     }
 
-    impl From<[FType; 3]> for Vec3 {
-        fn from(values: [FType; 3]) -> Self {
+    impl From<[Float; 3]> for Vec3 {
+        fn from(values: [Float; 3]) -> Self {
             Self {
                 x: values[0],
                 y: values[1],
@@ -337,7 +339,7 @@ mod math {
         }
     }
 
-    impl From<Vec3> for [FType; 3] {
+    impl From<Vec3> for [Float; 3] {
         fn from(v: Vec3) -> Self {
             [v.x, v.y, v.z]
         }

--- a/kolor/src/details/transform.rs
+++ b/kolor/src/details/transform.rs
@@ -2,12 +2,12 @@ use super::{
     color::{TransformFn, WhitePoint},
     math::prelude::*,
 };
-use crate::{FType, Mat3, Vec3, PI, TAU};
+use crate::{Float, Mat3, Vec3, PI, TAU};
 #[cfg(all(not(feature = "std"), feature = "libm"))]
 use num_traits::Float;
 
-/// [ColorTransform] represents a reference to a function that can apply a [TransformFn]
-/// or its inverse.
+/// Represents a reference to a function that can apply a [`TransformFn`] or
+/// its inverse.
 #[derive(Copy, Clone)]
 pub struct ColorTransform {
     first: for<'r> fn(Vec3, WhitePoint) -> Vec3,
@@ -17,12 +17,12 @@ impl ColorTransform {
     #[inline]
     pub fn new(src_transform: TransformFn, dst_transform: TransformFn) -> Option<Self> {
         use super::transform::*;
-        let from_transform = if src_transform == TransformFn::NONE {
+        let from_transform = if src_transform == TransformFn::None {
             None
         } else {
             Some(TRANSFORMS_INVERSE[src_transform as usize - 1])
         };
-        let to_transform = if dst_transform == TransformFn::NONE {
+        let to_transform = if dst_transform == TransformFn::None {
             None
         } else {
             Some(TRANSFORMS[dst_transform as usize - 1])
@@ -39,6 +39,7 @@ impl ColorTransform {
             })
         }
     }
+
     #[inline(always)]
     pub fn apply(&self, color: Vec3, white_point: WhitePoint) -> Vec3 {
         let mut color = (self.first)(color, white_point);
@@ -52,82 +53,83 @@ impl ColorTransform {
 // Keep in sync with TransformFn
 const TRANSFORMS: [fn(Vec3, WhitePoint) -> Vec3; 17] = [
     // sRGB,
-    sRGB_oetf,
+    srgb_oetf,
     // Oklab,
-    XYZ_to_Oklab,
+    xyz_to_ok_lab,
     // Oklch,
-    XYZ_to_Oklch,
-    //CIE_xyY,
-    XYZ_to_xyY,
-    //CIELAB,
-    XYZ_to_CIELAB,
-    //CIELCh,
-    XYZ_to_CIELCh,
-    //CIE_1960_UCS,
-    XYZ_to_CIE_1960_UCS,
-    //CIE_1960_UCS_uvV,
-    XYZ_to_CIE_1960_UCS_uvV,
-    //CIE_1964_UVW,
-    XYZ_to_CIE_1964_UVW,
-    //CIE_1976_Luv,
-    XYZ_to_CIE_1976_Luv,
-    //HSL,
-    hsx::RGB_to_HSL,
-    //HSV,
-    hsx::RGB_to_HSV,
-    //HSI,
-    hsx::RGB_to_HSI,
-    //ICtCp_PQ,
-    ICtCp::RGB_to_ICtCp_PQ,
-    //ICtCp_HLG,
-    ICtCp::RGB_to_ICtCp_HLG,
-    //BT_601,
+    xyz_to_ok_lch,
+    // CIE_xyY,
+    xyz_to_xyy,
+    // CIE LAB,
+    xyz_to_cie_lab,
+    // CIE LCh,
+    xyz_to_cie_lch,
+    // CIE 1960 UCS,
+    xyz_to_cie_1960_ucs,
+    // CIE 1960 UCS_uvV,
+    xyz_to_cie_1960_ucs_uvv,
+    // CIE 1964 UVW,
+    xyz_to_cie_1964_uvw,
+    // CIE 1976 Luv,
+    xyz_to_cie_1976_luv,
+    // HSL,
+    hsx::rgb_to_hsl,
+    // HSV,
+    hsx::rgb_to_hsv,
+    // HSI,
+    hsx::rgb_to_hsi,
+    // ICtCp PQ,
+    ict_cp::rgb_to_ict_cp_pq,
+    // ICtCp HLG,
+    ict_cp::rgb_to_ict_cp_hlg,
+    // BT 601,
     bt601_oetf,
-    //PQ,
-    ST_2084_PQ_eotf_inverse,
+    // PQ,
+    st_2084_pq_eotf_inverse,
 ];
 
 // Keep in sync with TransformFn
 const TRANSFORMS_INVERSE: [fn(Vec3, WhitePoint) -> Vec3; 17] = [
     // sRGB,
-    sRGB_eotf,
+    srgb_eotf,
     // Oklab,
-    Oklab_to_XYZ,
+    ok_lab_to_xyz,
     // Oklch,
-    Oklch_to_XYZ,
+    ok_lch_to_xyz,
     //CIE_xyY,
-    xyY_to_XYZ,
+    xyy_to_xyz,
     //CIELAB,
-    CIELAB_to_XYZ,
+    cie_lab_to_xyz,
     //CIELCh,
-    CIELCh_to_XYZ,
+    cie_lch_to_xyz,
     //CIE_1960_UCS,
-    CIE_1960_UCS_to_XYZ,
+    cie_1960_ucs_to_xyz,
     //CIE_1960_UCS_uvV,
-    CIE_1960_UCS_uvV_to_XYZ,
+    cie_1960_ucs_uvv_to_xyz,
     //CIE_1964_UVW,
-    CIE_1964_UVW_to_XYZ,
+    cie_1964_uvw_to_xyz,
     //CIE_1976_Luv,
-    CIE_1976_Luv_to_XYZ,
+    cie_1976_luv_to_xyz,
     //HSL,
-    hsx::HSL_to_RGB,
+    hsx::hsl_to_rgb,
     //HSV,
-    hsx::HSV_to_RGB,
+    hsx::hsv_to_rgb,
     //HSI,
-    hsx::HSI_to_RGB,
+    hsx::hsi_to_rgb,
     //ICtCp_PQ,
-    ICtCp::ICtCp_PQ_to_RGB,
+    ict_cp::ict_cp_pq_to_rgb,
     //ICtCp_HLG,
-    ICtCp::ICtCp_HLG_to_RGB,
+    ict_cp::ict_cp_hlg_to_rgb,
     //BT_601,
     bt601_oetf_inverse,
     //PQ,
-    ST_2084_PQ_eotf,
+    st_2084_pq_eotf,
 ];
 
-/// Applies the sRGB OETF (opto-eletronic transfer function), sometimes called "gamma compensation"
+/// Applies the sRGB OETF (opto-eletronic transfer function), sometimes called
+/// 'gamma compensation'.
 #[inline]
-pub fn sRGB_oetf(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn srgb_oetf(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let cutoff = color.cmplt(Vec3::splat(0.0031308));
     let higher = Vec3::splat(1.055) * color.powf(1.0 / 2.4) - Vec3::splat(0.055);
     let lower = color * Vec3::splat(12.92);
@@ -135,9 +137,10 @@ pub fn sRGB_oetf(color: Vec3, _wp: WhitePoint) -> Vec3 {
     Vec3::select(cutoff, lower, higher)
 }
 
-/// Applies the sRGB EOTF (electro-optical transfer function), which is also the direct inverse of the sRGB OETF.
+/// Applies the sRGB EOTF (electro-optical transfer function), which is also the
+/// direct inverse of the sRGB OETF.
 #[inline]
-pub fn sRGB_eotf(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn srgb_eotf(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let cutoff = color.cmplt(Vec3::splat(0.04045));
     let higher = ((color + Vec3::splat(0.055)) / 1.055).powf(2.4);
     let lower = color / 12.92;
@@ -145,7 +148,7 @@ pub fn sRGB_eotf(color: Vec3, _wp: WhitePoint) -> Vec3 {
     Vec3::select(cutoff, lower, higher)
 }
 
-// Applies the BT.601/BT.709/BT.2020 OETF
+/// Applies the BT.601/BT.709/BT.2020 OETF.
 #[inline]
 pub fn bt601_oetf(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let cutoff = color.cmplt(Vec3::splat(0.0181));
@@ -155,7 +158,7 @@ pub fn bt601_oetf(color: Vec3, _wp: WhitePoint) -> Vec3 {
     Vec3::select(cutoff, lower, higher)
 }
 
-// Applies the inverse of the BT.601/BT.709/BT.2020 OETF
+/// Applies the inverse of the BT.601/BT.709/BT.2020 OETF.
 #[inline]
 pub fn bt601_oetf_inverse(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let cutoff = color.cmplt(Vec3::splat(0.08145));
@@ -178,24 +181,25 @@ const OKLAB_M_2: Mat3 =
     -0.0040720468,0.4505937099,-0.8086757660]);
 
 #[inline]
-pub fn XYZ_to_Oklab(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn xyz_to_ok_lab(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let mut lms = OKLAB_M_1 * color;
-    // [cbrt] raises `lms` to (1. / 3.) but also avoids NaN when a component of `lms` is negative.
-    // `lms` can contain negative numbers in some cases like when `color` is (0.0, 0.0, 1.0)
+    // [cbrt] raises `lms` to (1. / 3.) but also avoids NaN when a component of
+    // `lms` is negative. `lms` can contain negative numbers in some cases like
+    // when `color` is (0.0, 0.0, 1.0)
     lms = lms.cbrt(); // non-linearity
     OKLAB_M_2 * lms
 }
 
 #[inline]
-pub fn Oklab_to_XYZ(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn ok_lab_to_xyz(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let mut lms = OKLAB_M_2.inverse() * color;
     lms = lms.powf(3.0); // reverse non-linearity
     OKLAB_M_1.inverse() * lms
 }
 
 #[inline]
-pub fn XYZ_to_Oklch(color: Vec3, _wp: WhitePoint) -> Vec3 {
-    let oklab = XYZ_to_Oklab(color, _wp);
+pub fn xyz_to_ok_lch(color: Vec3, _wp: WhitePoint) -> Vec3 {
+    let oklab = xyz_to_ok_lab(color, _wp);
     let lightness = oklab.x;
     let ab = oklab.yz();
     let chroma = ab.length();
@@ -204,7 +208,7 @@ pub fn XYZ_to_Oklch(color: Vec3, _wp: WhitePoint) -> Vec3 {
 }
 
 #[inline]
-pub fn Oklch_to_XYZ(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn ok_lch_to_xyz(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let lightness = color.x;
     let chroma = color.y;
     let hue = color.z;
@@ -212,11 +216,11 @@ pub fn Oklch_to_XYZ(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let a = chroma * hue_c;
     let b = chroma * hue_s;
     let oklab = Vec3::new(lightness, a, b);
-    Oklab_to_XYZ(oklab, _wp)
+    ok_lab_to_xyz(oklab, _wp)
 }
 
 #[inline]
-pub fn XYZ_to_xyY(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn xyz_to_xyy(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let x = color.x / (color.x + color.y + color.z);
     let y = color.y / (color.x + color.y + color.z);
     let Y = color.y;
@@ -224,7 +228,7 @@ pub fn XYZ_to_xyY(color: Vec3, _wp: WhitePoint) -> Vec3 {
 }
 
 #[inline]
-pub fn xyY_to_XYZ(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn xyy_to_xyz(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let x = (color.z / color.y) * color.x;
     let y = color.z;
     let z = (color.z / color.y) * (1.0 - color.x - color.y);
@@ -233,8 +237,8 @@ pub fn xyY_to_XYZ(color: Vec3, _wp: WhitePoint) -> Vec3 {
 
 // CIELAB
 #[inline]
-pub fn XYZ_to_CIELAB(color: Vec3, wp: WhitePoint) -> Vec3 {
-    fn magic_f(v: FType) -> FType {
+pub fn xyz_to_cie_lab(color: Vec3, wp: WhitePoint) -> Vec3 {
+    fn magic_f(v: Float) -> Float {
         if v > 0.008856 {
             v.powf(1.0 / 3.0)
         } else {
@@ -252,8 +256,9 @@ pub fn XYZ_to_CIELAB(color: Vec3, wp: WhitePoint) -> Vec3 {
 }
 
 #[inline]
-pub fn CIELAB_to_XYZ(color: Vec3, wp: WhitePoint) -> Vec3 {
-    fn magic_f_inverse(v: FType) -> FType {
+#[allow(non_snake_case)]
+pub fn cie_lab_to_xyz(color: Vec3, wp: WhitePoint) -> Vec3 {
+    fn magic_f_inverse(v: Float) -> Float {
         if v > 0.008856 {
             v.powf(3.0)
         } else {
@@ -272,17 +277,17 @@ pub fn CIELAB_to_XYZ(color: Vec3, wp: WhitePoint) -> Vec3 {
 
 // CIELCh
 #[inline]
-pub fn XYZ_to_CIELCh(color: Vec3, wp: WhitePoint) -> Vec3 {
-    XYZ_to_CIELAB(color, wp);
-    CIELAB_to_CIELCh(color)
+pub fn xyz_to_cie_lch(color: Vec3, wp: WhitePoint) -> Vec3 {
+    xyz_to_cie_lab(color, wp);
+    cie_lab_to_cie_lch(color)
 }
 #[inline]
-pub fn CIELCh_to_XYZ(color: Vec3, wp: WhitePoint) -> Vec3 {
-    CIELCh_to_CIELAB(color);
-    CIELAB_to_XYZ(color, wp)
+pub fn cie_lch_to_xyz(color: Vec3, wp: WhitePoint) -> Vec3 {
+    cie_lch_to_cie_lab(color);
+    cie_lab_to_xyz(color, wp)
 }
 #[inline]
-pub fn CIELAB_to_CIELCh(color: Vec3) -> Vec3 {
+pub fn cie_lab_to_cie_lch(color: Vec3) -> Vec3 {
     let mut h = color.z.atan2(color.y);
     if h > 0.0 {
         h = (h / PI) * 180.0;
@@ -293,7 +298,7 @@ pub fn CIELAB_to_CIELCh(color: Vec3) -> Vec3 {
     Vec3::new(color.x, C, h)
 }
 #[inline]
-pub fn CIELCh_to_CIELAB(color: Vec3) -> Vec3 {
+pub fn cie_lch_to_cie_lab(color: Vec3) -> Vec3 {
     let angle = (color.z / 360.0) * TAU;
     let a = color.y * angle.cos();
     let b = color.y * angle.sin();
@@ -302,7 +307,7 @@ pub fn CIELCh_to_CIELAB(color: Vec3) -> Vec3 {
 
 // CIE 1960 UCS
 #[inline]
-pub fn XYZ_to_CIE_1960_UCS(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn xyz_to_cie_1960_ucs(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let U = (2.0 / 3.0) * color.x;
     let V = color.y;
     let W = 0.5 * (-color.x + 3.0 * color.y + color.z);
@@ -310,7 +315,7 @@ pub fn XYZ_to_CIE_1960_UCS(color: Vec3, _wp: WhitePoint) -> Vec3 {
 }
 
 #[inline]
-pub fn CIE_1960_UCS_to_XYZ(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn cie_1960_ucs_to_xyz(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let X = (3.0 / 2.0) * color.x;
     let Y = color.y;
     let Z = (3.0 / 2.0) * color.x - 3.0 * color.y + 2.0 * color.z;
@@ -318,16 +323,16 @@ pub fn CIE_1960_UCS_to_XYZ(color: Vec3, _wp: WhitePoint) -> Vec3 {
 }
 
 #[inline]
-pub fn CIE_1960_UCS_uvV_to_XYZ(color: Vec3, wp: WhitePoint) -> Vec3 {
-    CIE_1960_UCS_to_XYZ(CIE_1960_uvV_to_UCS(color, wp), wp)
+pub fn cie_1960_ucs_uvv_to_xyz(color: Vec3, wp: WhitePoint) -> Vec3 {
+    cie_1960_ucs_to_xyz(cie_1960_uvv_to_ucs(color, wp), wp)
 }
 #[inline]
-pub fn XYZ_to_CIE_1960_UCS_uvV(color: Vec3, wp: WhitePoint) -> Vec3 {
-    CIE_1960_UCS_to_uvV(XYZ_to_CIE_1960_UCS(color, wp), wp)
+pub fn xyz_to_cie_1960_ucs_uvv(color: Vec3, wp: WhitePoint) -> Vec3 {
+    cie_1960_ucs_to_uvv(xyz_to_cie_1960_ucs(color, wp), wp)
 }
 
 #[inline]
-pub fn CIE_1960_UCS_to_uvV(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn cie_1960_ucs_to_uvv(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let u_v_w = color.x + color.y + color.z;
 
     let u = color.x / u_v_w;
@@ -336,14 +341,14 @@ pub fn CIE_1960_UCS_to_uvV(color: Vec3, _wp: WhitePoint) -> Vec3 {
 }
 
 #[inline]
-pub fn CIE_1960_uvV_to_UCS(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn cie_1960_uvv_to_ucs(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let U = color.z * (color.x / color.y);
     let W = -color.z * (color.x + color.y - 1.0) / color.y;
     Vec3::new(U, color.y, W)
 }
 
 #[inline]
-pub fn CIE_1960_uvV_to_xyV(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn cie_1960_uvv_to_xyv(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let d = 2.0 * color.x - 8.0 * color.y - 4.0;
     let x = 3.0 * (color.x / d);
     let y = 2.0 * (color.y / d);
@@ -351,17 +356,17 @@ pub fn CIE_1960_uvV_to_xyV(color: Vec3, _wp: WhitePoint) -> Vec3 {
 }
 
 #[inline]
-pub fn CIE_1960_xyV_to_uvV(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn cie_1960_xyv_to_uvv(color: Vec3, _wp: WhitePoint) -> Vec3 {
     let d = 12.0 * color.y - 2.0 * color.x + 3.0;
     let u = 4.0 * (color.x / d);
     let v = 6.0 * (color.y / d);
     Vec3::new(u, v, color.z)
 }
 
-// TODO finish implementing this. The wikipedia articles are so convoluted, jeez.
-// CIE 1964 UVW
+// TODO finish implementing this. The wikipedia articles are so convoluted,
+// jeez. CIE 1964 UVW
 #[inline]
-pub fn XYZ_to_CIE_1964_UVW(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn xyz_to_cie_1964_uvw(_color: Vec3, _wp: WhitePoint) -> Vec3 {
     //     // Convert the white point to uvV form
     //     let mut wp_value = Vec3::from_slice(wp.values());
     //     XYZ_to_CIE_1960_UCS(&mut wp_value, wp);
@@ -378,18 +383,18 @@ pub fn XYZ_to_CIE_1964_UVW(color: Vec3, _wp: WhitePoint) -> Vec3 {
     //     let U = 13.0 * W * (uvV.x - wp_value.x);
     //     let V = 13.0 * W * (uvV.y - wp_value.y);
     //     *color = Vec3::new(U, V, W);
-    color
+    todo!();
 }
 
 #[inline]
-pub fn CIE_1964_UVW_to_XYZ(color: Vec3, _wp: WhitePoint) -> Vec3 {
+pub fn cie_1964_uvw_to_xyz(_color: Vec3, _wp: WhitePoint) -> Vec3 {
     // TODO
-    color
+    todo!();
 }
 
 // CIE 1976 Luv
 #[inline]
-pub fn XYZ_to_CIE_1976_Luv(color: Vec3, wp: WhitePoint) -> Vec3 {
+pub fn xyz_to_cie_1976_luv(color: Vec3, wp: WhitePoint) -> Vec3 {
     let U = (4.0 * color.x) / (color.x + (15.0 * color.y) + (3.0 * color.z));
     let V = (9.0 * color.y) / (color.x + (15.0 * color.y) + (3.0 * color.z));
 
@@ -415,7 +420,7 @@ pub fn XYZ_to_CIE_1976_Luv(color: Vec3, wp: WhitePoint) -> Vec3 {
 
 // Inverse of CIE 1976 Luv
 #[inline]
-pub fn CIE_1976_Luv_to_XYZ(color: Vec3, wp: WhitePoint) -> Vec3 {
+pub fn cie_1976_luv_to_xyz(color: Vec3, wp: WhitePoint) -> Vec3 {
     let Y = (color.x + 16.0) / 116.0;
     let Y = if Y.powf(3.0) > 0.008856 {
         Y.powf(3.0)
@@ -443,11 +448,11 @@ pub fn CIE_1976_Luv_to_XYZ(color: Vec3, wp: WhitePoint) -> Vec3 {
 #[allow(non_upper_case_globals)]
 pub mod hlg {
     use super::*;
-    const HLG_a: FType = 0.17883277;
-    const HLG_b: FType = 0.28466892;
-    const HLG_c: FType = 0.55991073;
-    const HLG_r: FType = 0.5;
-    fn HLG_channel(E: FType) -> FType {
+    const HLG_a: Float = 0.17883277;
+    const HLG_b: Float = 0.28466892;
+    const HLG_c: Float = 0.55991073;
+    const HLG_r: Float = 0.5;
+    fn HLG_channel(E: Float) -> Float {
         if E <= 1.0 {
             HLG_r * E.sqrt()
         } else {
@@ -457,7 +462,7 @@ pub mod hlg {
     /// ARIB STD-B67 or "Hybrid Log-Gamma"
     #[allow(non_upper_case_globals)]
     #[inline]
-    pub fn ARIB_HLG_oetf(color: Vec3, _wp: WhitePoint) -> Vec3 {
+    pub fn arib_hlg_oetf(color: Vec3, _wp: WhitePoint) -> Vec3 {
         Vec3::new(
             HLG_channel(color.x),
             HLG_channel(color.y),
@@ -466,10 +471,9 @@ pub mod hlg {
     }
 
     /// Inverse of ARIB STD-B67 or "Hybrid Log-Gamma"
-    #[allow(non_upper_case_globals)]
     #[inline]
-    pub fn ARIB_HLG_oetf_inverse(color: Vec3, _wp: WhitePoint) -> Vec3 {
-        fn HLG_channel_inverse(E_p: FType) -> FType {
+    pub fn arib_hlg_oetf_inverse(color: Vec3, _wp: WhitePoint) -> Vec3 {
+        fn HLG_channel_inverse(E_p: Float) -> Float {
             if E_p <= HLG_channel(1.0) {
                 (E_p / HLG_r).powf(2.0)
             } else {
@@ -486,39 +490,39 @@ pub mod hlg {
 
 pub use hlg::*;
 
-/// SMPTE ST 2084:2014 EOTF aka "Perceptual Quantizer" used in BT.2100
+/// SMPTE ST 2084:2014 EOTF aka 'Perceptual Quantizer' used in BT.2100
 #[allow(non_upper_case_globals)]
 pub mod pq {
     use super::*;
-    const L_p: FType = 10000.0;
-    const M_1: FType = 0.1593017578125;
-    const M_2: FType = 78.84375;
-    const M_1_d: FType = 1.0 / M_1;
-    const M_2_d: FType = 1.0 / M_2;
-    const C_1: FType = 0.8359375;
-    const C_2: FType = 18.8515625;
-    const C_3: FType = 18.6875;
+    const L_p: Float = 10000.0;
+    const M_1: Float = 0.1593017578125;
+    const M_2: Float = 78.84375;
+    const M_1_d: Float = 1.0 / M_1;
+    const M_2_d: Float = 1.0 / M_2;
+    const C_1: Float = 0.8359375;
+    const C_2: Float = 18.8515625;
+    const C_3: Float = 18.6875;
 
-    /// SMPTE ST 2084:2014 perceptual electo-optical transfer function inverse
+    /// SMPTE ST 2084:2014 perceptual electo-optical transfer function inverse.
     #[inline]
-    pub fn ST_2084_PQ_eotf_inverse_float(f: FType) -> FType {
+    pub fn st_2084_pq_eotf_inverse_float(f: Float) -> Float {
         let Y_p = (f / L_p).powf(M_1);
         ((C_1 + C_2 * Y_p) / (C_3 * Y_p + 1.0)).powf(M_2)
     }
 
-    /// SMPTE ST 2084:2014 perceptual electo-optical transfer function inverse
+    /// SMPTE ST 2084:2014 perceptual electo-optical transfer function inverse.
     #[inline]
-    pub fn ST_2084_PQ_eotf_inverse(color: Vec3, _wp: WhitePoint) -> Vec3 {
+    pub fn st_2084_pq_eotf_inverse(color: Vec3, _wp: WhitePoint) -> Vec3 {
         Vec3::new(
-            ST_2084_PQ_eotf_inverse_float(color.x),
-            ST_2084_PQ_eotf_inverse_float(color.y),
-            ST_2084_PQ_eotf_inverse_float(color.z),
+            st_2084_pq_eotf_inverse_float(color.x),
+            st_2084_pq_eotf_inverse_float(color.y),
+            st_2084_pq_eotf_inverse_float(color.z),
         )
     }
 
-    /// SMPTE ST 2084:2014 perceptual electo-optical transfer function inverse
+    /// SMPTE ST 2084:2014 perceptual electo-optical transfer function inverse.
     #[inline]
-    pub fn ST_2084_PQ_eotf_float(f: FType) -> FType {
+    pub fn st_2084_pq_eotf_float(f: Float) -> Float {
         let V_p = f.powf(M_2_d);
 
         let n = (V_p - C_1).max(0.0);
@@ -526,13 +530,13 @@ pub mod pq {
         L_p * L
     }
 
-    /// SMPTE ST 2084:2014 perceptual electro-optical transfer function
+    /// SMPTE ST 2084:2014 perceptual electro-optical transfer function.
     #[inline]
-    pub fn ST_2084_PQ_eotf(color: Vec3, _wp: WhitePoint) -> Vec3 {
+    pub fn st_2084_pq_eotf(color: Vec3, _wp: WhitePoint) -> Vec3 {
         Vec3::new(
-            ST_2084_PQ_eotf_float(color.x),
-            ST_2084_PQ_eotf_float(color.y),
-            ST_2084_PQ_eotf_float(color.z),
+            st_2084_pq_eotf_float(color.x),
+            st_2084_pq_eotf_float(color.y),
+            st_2084_pq_eotf_float(color.z),
         )
     }
 }
@@ -540,93 +544,87 @@ pub mod pq {
 pub use pq::*;
 
 /// BT.2100 ICtCp
-pub mod ICtCp {
+pub mod ict_cp {
     use super::*;
 
     #[rustfmt::skip]
-    #[allow(non_upper_case_globals)]
-    pub(crate) const ICtCp_LMS: Mat3 = Mat3::from_cols_array(&[
+    pub(crate) const ICT_CP_LMS: Mat3 = Mat3::from_cols_array(&[
         0.412109, 0.166748, 0.0241699,
         0.523926, 0.720459, 0.0754395,
         0.0639648, 0.112793, 0.900391,
     ]);
 
     #[rustfmt::skip]
-    #[allow(non_upper_case_globals)]
-    pub(crate) const ICtCp_LMS_INVERSE: Mat3 = Mat3::from_cols_array(&[
+    pub(crate) const ICT_CP_LMS_INVERSE: Mat3 = Mat3::from_cols_array(&[
         3.43661, -0.79133, -0.0259498,
         -2.50646, 1.9836, -0.0989137,
         0.0698454, -0.192271, 1.12486,
     ]);
 
     #[rustfmt::skip]
-    #[allow(non_upper_case_globals)]
-    pub(crate) const ICtCp_From_PQ_INVERSE: Mat3 = Mat3::from_cols_array(&[
+    pub(crate) const ICT_CP_FROM_PQ_INVERSE: Mat3 = Mat3::from_cols_array(&[
         1.0, 1.0, 1.0,
         0.00860904, -0.00860904, 0.560031,
         0.11103, -0.11103, -0.320627,
     ]);
 
     #[rustfmt::skip]
-    #[allow(non_upper_case_globals)]
-    pub(crate) const ICtCp_From_PQ: Mat3 = Mat3::from_cols_array(&[
+    pub(crate) const ICT_CP_FROM_PQ: Mat3 = Mat3::from_cols_array(&[
         0.5, 1.61377, 4.37817,
         0.5, -3.32349, -4.24561,
         0.0, 1.70972, -0.132568,
     ]);
 
-    /// ICtCp with the HLG transfer function
+    /// ICtCp with the HLG transfer function.
     #[inline]
-    pub fn RGB_to_ICtCp_HLG(color: Vec3, wp: WhitePoint) -> Vec3 {
+    pub fn rgb_to_ict_cp_hlg(color: Vec3, wp: WhitePoint) -> Vec3 {
         #[rustfmt::skip]
-        #[allow(non_upper_case_globals)]
-        const ICtCp_From_HLG: Mat3 = Mat3::from_cols_array(&[
+        const ICT_CP_FROM_HLG: Mat3 = Mat3::from_cols_array(&[
             0.5, 0.88501, 2.31934,
             0.5, -1.82251, -2.24902,
             0.0, 0.9375, -0.0703125
         ]);
-        let lms = ICtCp_LMS * color;
-        let hlg = hlg::ARIB_HLG_oetf(lms, wp);
-        ICtCp_From_HLG * hlg
+        let lms = ICT_CP_LMS * color;
+        let hlg = hlg::arib_hlg_oetf(lms, wp);
+        ICT_CP_FROM_HLG * hlg
     }
 
-    /// Inverse ICtCp with the HLG transfer function
+    /// Inverse ICtCp with the HLG transfer function.
     #[inline]
-    pub fn ICtCp_HLG_to_RGB(color: Vec3, wp: WhitePoint) -> Vec3 {
+    pub fn ict_cp_hlg_to_rgb(color: Vec3, wp: WhitePoint) -> Vec3 {
         #[rustfmt::skip]
-        #[allow(non_upper_case_globals)]
-        const ICtCp_From_HLG_INVERSE: Mat3 = Mat3::from_cols_array(&[
+        const ICT_CP_FROM_HLG_INVERSE: Mat3 = Mat3::from_cols_array(&[
             0.999998, 1.0, 1.0,
             0.0157186, -0.0157186, 1.02127,
             0.209581, -0.209581, -0.605275,
         ]);
-        let lms_hlg = ICtCp_From_HLG_INVERSE * color;
-        let lms = hlg::ARIB_HLG_oetf_inverse(lms_hlg, wp);
-        ICtCp_LMS_INVERSE * lms
+        let lms_hlg = ICT_CP_FROM_HLG_INVERSE * color;
+        let lms = hlg::arib_hlg_oetf_inverse(lms_hlg, wp);
+        ICT_CP_LMS_INVERSE * lms
     }
 
-    /// ICtCp with the PQ transfer function
+    /// ICtCp with the PQ transfer function.
     #[inline]
-    pub fn RGB_to_ICtCp_PQ(color: Vec3, _wp: WhitePoint) -> Vec3 {
-        let lms = ICtCp_LMS * color;
-        let pq = pq::ST_2084_PQ_eotf_inverse(lms, WhitePoint::D65);
-        ICtCp_From_PQ * pq
+    pub fn rgb_to_ict_cp_pq(color: Vec3, _wp: WhitePoint) -> Vec3 {
+        let lms = ICT_CP_LMS * color;
+        let pq = pq::st_2084_pq_eotf_inverse(lms, WhitePoint::D65);
+        ICT_CP_FROM_PQ * pq
     }
-    /// Inverse ICtCp with the PQ transfer function
+    /// Inverse ICtCp with the PQ transfer function.
     #[inline]
-    pub fn ICtCp_PQ_to_RGB(color: Vec3, _wp: WhitePoint) -> Vec3 {
-        let lms_pq = ICtCp_From_PQ_INVERSE * color;
-        let lms = pq::ST_2084_PQ_eotf(lms_pq, WhitePoint::D65);
-        ICtCp_LMS_INVERSE * lms
+    pub fn ict_cp_pq_to_rgb(color: Vec3, _wp: WhitePoint) -> Vec3 {
+        let lms_pq = ICT_CP_FROM_PQ_INVERSE * color;
+        let lms = pq::st_2084_pq_eotf(lms_pq, WhitePoint::D65);
+        ICT_CP_LMS_INVERSE * lms
     }
 }
 
-pub use ICtCp::*;
+pub use ict_cp::*;
 
-/// transforms for Hue/Saturation/X color models, like HSL, HSI, HSV
+/// Transforms for Hue/Saturation/X color models, like HSL, HSI, HSV.
 pub mod hsx {
     use super::*;
-    fn HSX_hue_and_chroma_from_RGB(color: Vec3, x_max: FType, x_min: FType) -> (FType, FType) {
+    fn hsx_hue_and_chroma_from_rgb(color: Vec3, x_max: Float, x_min: Float) -> (Float, Float) {
         let chroma = x_max - x_min;
         let hue = if chroma == 0.0 {
             0.0
@@ -642,8 +640,8 @@ pub mod hsx {
     }
 
     #[inline]
-    pub fn RGB_to_HSL(color: Vec3, _wp: WhitePoint) -> Vec3 {
-        RGB_to_HSX(color, |_, x_max, x_min, _| {
+    pub fn rgb_to_hsl(color: Vec3, _wp: WhitePoint) -> Vec3 {
+        rgb_to_hsx(color, |_, x_max, x_min, _| {
             let lightness = (x_max + x_min) / 2.0;
             let saturation = if lightness <= 0.0 || lightness >= 1.0 {
                 0.0
@@ -655,8 +653,8 @@ pub mod hsx {
     }
 
     #[inline]
-    pub fn RGB_to_HSV(color: Vec3, _wp: WhitePoint) -> Vec3 {
-        RGB_to_HSX(color, |_, max, _, chroma| {
+    pub fn rgb_to_hsv(color: Vec3, _wp: WhitePoint) -> Vec3 {
+        rgb_to_hsx(color, |_, max, _, chroma| {
             let value = max;
             let saturation = if value == 0.0 { 0.0 } else { chroma / value };
             (saturation, value)
@@ -664,8 +662,8 @@ pub mod hsx {
     }
 
     #[inline]
-    pub fn RGB_to_HSI(color: Vec3, _wp: WhitePoint) -> Vec3 {
-        RGB_to_HSX(color, |color, _, min, _| {
+    pub fn rgb_to_hsi(color: Vec3, _wp: WhitePoint) -> Vec3 {
+        rgb_to_hsx(color, |color, _, min, _| {
             let intensity = (color.x + color.y + color.z) * (1.0 / 3.0);
             let saturation = if intensity == 0.0 {
                 0.0
@@ -677,34 +675,34 @@ pub mod hsx {
     }
 
     #[inline(always)]
-    fn RGB_to_HSX<F: FnOnce(Vec3, FType, FType, FType) -> (FType, FType)>(
+    fn rgb_to_hsx<F: FnOnce(Vec3, Float, Float, Float) -> (Float, Float)>(
         color: Vec3,
         f: F,
     ) -> Vec3 {
         let x_max = color.x.max(color.y.max(color.z));
         let x_min = color.x.min(color.y.min(color.z));
-        let (hue, chroma) = HSX_hue_and_chroma_from_RGB(color, x_max, x_min);
+        let (hue, chroma) = hsx_hue_and_chroma_from_rgb(color, x_max, x_min);
         let (saturation, vli) = f(color, x_max, x_min, chroma);
 
         Vec3::new(hue, saturation, vli)
     }
 
     #[inline(always)]
-    fn HSX_to_RGB<
+    fn hsx_to_rgb<
         F: FnOnce(
             Vec3,
         ) -> (
-            /* hue_prime: */ FType,
-            /*chroma: */ FType,
-            /*largest_component: */ FType,
-            /*lightness_match:*/ FType,
+            /* hue_prime: */ Float,
+            /* chroma: */ Float,
+            /* largest_component: */ Float,
+            /* lightness_match: */ Float,
         ),
     >(
         color: Vec3,
         f: F,
     ) -> Vec3 {
         let (hue_prime, chroma, largest_component, lightness_match) = f(color);
-        let (r, g, b) = RGB_from_HCX(hue_prime, chroma, largest_component);
+        let (r, g, b) = rgb_from_hcx(hue_prime, chroma, largest_component);
         Vec3::new(
             r + lightness_match,
             g + lightness_match,
@@ -712,8 +710,8 @@ pub mod hsx {
         )
     }
     #[inline]
-    pub fn HSL_to_RGB(color: Vec3, _wp: WhitePoint) -> Vec3 {
-        HSX_to_RGB(color, |color| {
+    pub fn hsl_to_rgb(color: Vec3, _wp: WhitePoint) -> Vec3 {
+        hsx_to_rgb(color, |color| {
             let chroma = (1.0 - (2.0 * color.z - 1.0).abs()) * color.y;
             let hue_prime = color.x / 60.0;
             let largest_component = chroma * (1.0 - (hue_prime % 2.0 - 1.0).abs());
@@ -723,8 +721,8 @@ pub mod hsx {
     }
 
     #[inline]
-    pub fn HSV_to_RGB(color: Vec3, _wp: WhitePoint) -> Vec3 {
-        HSX_to_RGB(color, |color| {
+    pub fn hsv_to_rgb(color: Vec3, _wp: WhitePoint) -> Vec3 {
+        hsx_to_rgb(color, |color| {
             let chroma = color.z * color.y;
             let hue_prime = color.x / 60.0;
             let largest_component = chroma * (1.0 - (hue_prime % 2.0 - 1.0).abs());
@@ -734,8 +732,8 @@ pub mod hsx {
     }
 
     #[inline]
-    pub fn HSI_to_RGB(color: Vec3, _wp: WhitePoint) -> Vec3 {
-        HSX_to_RGB(color, |color| {
+    pub fn hsi_to_rgb(color: Vec3, _wp: WhitePoint) -> Vec3 {
+        hsx_to_rgb(color, |color| {
             let hue_prime = color.x / 60.0;
             let z = 1.0 - (hue_prime % 2.0 - 1.0).abs();
             let chroma = (3.0 * color.z * color.y) / (1.0 + z);
@@ -746,11 +744,11 @@ pub mod hsx {
     }
 
     #[inline(always)]
-    fn RGB_from_HCX(
-        hue_prime: FType,
-        chroma: FType,
-        largest_component: FType,
-    ) -> (FType, FType, FType) {
+    fn rgb_from_hcx(
+        hue_prime: Float,
+        chroma: Float,
+        largest_component: Float,
+    ) -> (Float, Float, Float) {
         let (r, g, b) = if hue_prime < 1.0 {
             (chroma, largest_component, 0.0)
         } else if hue_prime < 2.0 {
@@ -778,12 +776,12 @@ mod test {
     use super::*;
     #[test]
     fn ictcp_pq_inverse() {
-        let to_conv = ColorConversion::new(spaces::LINEAR_SRGB, spaces::ICtCp_PQ);
-        let from_conv = ColorConversion::new(spaces::ICtCp_PQ, spaces::LINEAR_SRGB);
+        let to_conv = ColorConversion::new(spaces::LINEAR_SRGB, spaces::ICT_CP_PQ);
+        let from_conv = ColorConversion::new(spaces::ICT_CP_PQ, spaces::LINEAR_SRGB);
         let value = 0.5;
 
-        let pq_val = crate::details::transform::pq::ST_2084_PQ_eotf_inverse_float(value);
-        let inverse_val = crate::details::transform::pq::ST_2084_PQ_eotf_float(pq_val);
+        let pq_val = crate::details::transform::pq::st_2084_pq_eotf_inverse_float(value);
+        let inverse_val = crate::details::transform::pq::st_2084_pq_eotf_float(pq_val);
         assert!(
             (value - inverse_val).abs() < 0.001,
             "pq_val {:?} inverse {:?}",
@@ -792,7 +790,7 @@ mod test {
         );
         // validate inverse matrices
         let value = Vec3::new(0.5, 0.5, 0.5);
-        let result = ICtCp::ICtCp_From_PQ_INVERSE * (ICtCp::ICtCp_From_PQ * value);
+        let result = ict_cp::ICT_CP_FROM_PQ_INVERSE * (ict_cp::ICT_CP_FROM_PQ * value);
         assert!(
             value.abs_diff_eq(result, 0.0001),
             "{:?} != {:?}",
@@ -800,7 +798,7 @@ mod test {
             result
         );
 
-        let result = ICtCp::ICtCp_LMS_INVERSE * (ICtCp::ICtCp_LMS * value);
+        let result = ict_cp::ICT_CP_LMS_INVERSE * (ict_cp::ICT_CP_LMS * value);
         assert!(
             value.abs_diff_eq(result, 0.0001),
             "{:?} != {:?}",

--- a/kolor/src/details/xyz.rs
+++ b/kolor/src/details/xyz.rs
@@ -1,12 +1,12 @@
-use crate::{FType, Mat3, Vec3};
+use crate::{Float, Mat3, Vec3};
 
-pub fn xyz_to_rgb(primaries: &[[FType; 2]; 3], white_point: &[FType; 3]) -> Mat3 {
+pub fn xyz_to_rgb(primaries: &[[Float; 2]; 3], white_point: &[Float; 3]) -> Mat3 {
     rgb_to_xyz(primaries, white_point).inverse()
 }
 
 #[rustfmt::skip]
 #[allow(non_snake_case)]
-pub fn rgb_to_xyz(primaries: &[[FType;2]; 3], white_point: &[FType;3]) -> Mat3 {
+pub fn rgb_to_xyz(primaries: &[[Float;2]; 3], white_point: &[Float;3]) -> Mat3 {
     let [[xr, yr], [xg, yg], [xb, yb]] = *primaries;
     let [Wx, Wy, Wz] = *white_point;
 

--- a/kolor/src/lib.rs
+++ b/kolor/src/lib.rs
@@ -1,121 +1,153 @@
-//! kolor implements conversions between color spaces which use 3-component vectors.
+//! `kolor` implements conversions between color spaces which use 3-component
+//! vectors.
 //!
-//! kolor is intended for use in games or other interactive visual applications,
-//! where it can help implement correct color management and wide color gamut rendering.
+//! It is intended for use in games or other interactive visual applications,
+//! where it can help implement correct color management and wide color gamut
+//! rendering.
 //!
-//! # Named color spaces
-//! Named color space definitions can be found in [spaces]. Some notable color spaces and models:
+//! ## Named Color Spaces
 //!
-//! - sRGB / linear sRGB / BT.709
-//! - BT.2020
-//! - ACEScg
-//! - ACES2065-1
-//! - Oklab
-//! - CIE LAB / Lch / Luv / xyY / uvV
-//! - HSL / HSV / HSI
-//! - ICtCp
+//! Named color space definitions can be found in the [`spaces`] module. Some
+//! notable color spaces and models:
 //!
-//! You can also construct custom [ColorSpace]s
-//! from a combination of primaries, whitepoint and transform function.
+//! * sRGB/linear sRGB/BT.709
+//! * BT.2020
+//! * ACEScg
+//! * ACES2065-1
+//! * Oklab
+//! * CIE LAB/Lch/Luv/xyY/uvV
+//! * HSL/HSV/HSI
+//! * ICtCp
 //!
-//! # Design
-//! kolor aims to supports all color spaces and color models which use 3-component vectors,
-//! such as RGB, LAB, XYZ, HSL and more.
+//! You can also construct custom [`ColorSpace`]s from a combination of
+//! primaries, whitepoint and transform function.
 //!
-//! In the spirit of keeping things simple, kolor uses a single type, [Color], to represent
-//! a color in any supported color space.
+//! ## Design
 //!
-//! kolor can programmatically generate an efficient conversion between any two color spaces
-//! by using the CIE XYZ color space as a "connecting space", meaning all supported color spaces
-//! only need to support a conversion to a reference color space that is a linear
-//! transform of the CIE XYZ color space.
+//! `kolor` aims to supports all color spaces and color models which use
+//! 3-component vectors, such as RGB, LAB, XYZ, HSL and more.
 //!
-//! Transformations between linear color spaces can be implemented with a 3x3 matrix, and
-//! since 3x3 matrices are composable, these matrices can be pre-composed and applied to a color
-//! with a single multiply.
+//! In the spirit of keeping things simple, `kolor` uses a single type,
+//! [`Color`], to represent a color in any supported color space.
 //!
-//! kolor recognizes that users may want to perform conversions on colors stored in types defined
-//! by the user. [ColorConversion] represents a conversion between two color spaces
-//! and is intended to be compatible with 3-component vectors in many math libraries.
+//! `kolor` can programmatically generate an efficient conversion between any
+//! two color spaces by using the CIE XYZ color space as a "connecting space",
+//! meaning all supported color spaces only need to support a conversion to a
+//! reference color space that is a linear transform of the CIE XYZ color space.
 //!
-//! kolor defines conversions from a source [ColorSpace] to a destination [ColorSpace] as three parts:
-//! - if the source color space is non-linear,
-//!     apply the inverse of its transform function to convert to the non-linear color space's reference
-//!     color space (which is always linear)
-//! - a linear 3x3 transformation matrix from the source to the destination linear color space
-//! - if the destination color space is a non-linear color space,
-//!     apply its transform function
+//! Transformations between linear color spaces can be implemented with a 3×3
+//! matrix, and since 3×3 matrices are composable, these matrices can be
+//! pre-composed and applied to a color with a single multiply.
 //!
-//! A "non-linear transform function" means any function that cannot be expressed as a linear transformation
-//! of the CIE XYZ color space. Examples include the sRGB logarithmic gamma compensation function,
+//! `kolor` recognizes that users may want to perform conversions on colors
+//! stored in types defined by the user. [`ColorConversion`] represents a
+//! conversion between two color spaces and is intended to be compatible with
+//! 3-component vectors in many math libraries.
+//!
+//! `kolor` defines conversions from a source `ColorSpace` to a destination
+//! `ColorSpace` as three parts:
+//!
+//! - if the source color space is non-linear, apply the inverse of its
+//!   transform function to convert to the non-linear color space's reference
+//!   color space (which is always linear).
+//!
+//! - a linear 3×3 transformation matrix from the source to the destination
+//!   linear color space.
+//!
+//! - if the destination color space is a non-linear color space, apply its
+//!   transform function
+//!
+//! A "non-linear transform function" means any function that cannot be
+//! expressed as a linear transformation of the CIE XYZ color space. Examples
+//! include the sRGB logarithmic gamma compensation function,
 //! the Oklab transform function, and the HSL/HSV hexagonal/circular transform.
 //!
 //! For non-linear color spaces, many transform functions are supported
-//! to convert between popular spaces, but for GPU contexts, these implementations clearly can't be used directly.
-//! To implement data-driven conversions, you can read the required operations for transforming between spaces
-//! from a [ColorConversion] value and run these as appropriate.
-//! Feel free to port the implementations in [details::transform] to your shaders or other code.
+//! to convert between popular spaces, but for GPU contexts, these
+//! implementations clearly can't be used directly. To implement data-driven
+//! conversions, you can read the required operations for transforming between
+//! spaces from a `ColorConversion` value and run these as appropriate.
+//! Feel free to port the implementations in the
+//! [`transform`](`details::transform`) module to your shaders or other code.
 //!
+//! ### Gamut-Agnostic Transforms
 //!
-//! ### Gamut-agnostic transforms
-//! Some color models like CIELAB or HSL are intended to provide an alternate view of
-//! some linear color spaces, and need a reference color space to provide information like
-//! which white point or RGB primaries to use.
-//! To construct these color spaces, refer to associated methods on [ColorSpace] and use an appropriate
-//! reference color space.
+//! Some color models like CIELAB or HSL are intended to provide an alternate
+//! view of some linear color spaces, and need a reference color space to
+//! provide information like which white point or RGB primaries to use. To
+//! construct these color spaces, refer to associated methods on `ColorSpace`
+//! and use an appropriate reference color space.
 //!
+//! ### Details
 //!
-//! # Details
-//! kolor can calculate 3x3 conversion matrices between any linear color space
-//! defined by RGB primaries and a white point. kolor offers APIs for performing
-//! conversions directly, and for extracting the 3x3 matrix to use in a different context,
-//! for example on a GPU.
+//! `kolor` can calculate 3×3 conversion matrices between any linear color space
+//! defined by RGB primaries and a white point. `kolor` offers APIs for
+//! performing conversions directly, and for extracting the 3×3 matrix to use in
+//! a different context, for example on a GPU.
 //!
-//! ### Generating conversion matrices between RGB color spaces
-//! [LinearColorConversion][details::conversion::LinearColorConversion] can be used
-//! to generate conversion matrices "offline",
-//! in which case you probably want to use the `f64` feature for better precision.
-//! The precision of the derived matrices won't be perfect, but probably good enough for games.
+//! ### Generating Conversion Matrices Between RGB Color Spaces
 //!
-//! Conversions between all combinations of built-in primaries and whitepoints color spaces
-//! are bundled with kolor as constants with the `color-matrices` feature, which is enabled by default.
-//! When a [ColorConversion] without a bundled pre-calculated conversion matrix is created,
-//! it is calculated on-demand, meaning the creation will be a bit slower to create than
-//! if there is a constant matrix available.
+//! [`LinearColorConversion`][details::conversion::LinearColorConversion] can be
+//! used to generate conversion matrices "offline",
+//! in which case you probably want to use the `f64` feature for better
+//! precision. The precision of the derived matrices won't be perfect, but
+//! probably good enough for games.
+//!
+//! Conversions between all combinations of built-in primaries and whitepoints
+//! color spaces are bundled with `kolor` as constants with the `color-matrices`
+//! feature, which is enabled by default. When a `ColorConversion` without a
+//! bundled pre-calculated conversion matrix is created, it is calculated
+//! on-demand, meaning the creation will be a bit slower to create than if there
+//! is a constant matrix available.
 //!
 //! ### Chromatic Adaptation Transformation (CAT)
-//! kolor implements CAT in [details::cat] and supports the LMS cone spaces defined
-//! in [LMSConeSpace][details::cat::LMSConeSpace]. Chromatic Adaptation Transformation means converting
-//! a linear RGB color space from one reference [WhitePoint][details::color::WhitePoint] to another.
 //!
-//! Use [ColorSpace::with_whitepoint] to change [WhitePoint][details::color::WhitePoint] for a color space.
+//! `kolor` implements CAT in the [`cat`](details::cat) module and supports the
+//! LMS cone spaces defined in [`LmsConeSpace`][details::cat::LmsConeSpace].
+//! Chromatic Adaptation Transformation means converting a linear RGB color
+//! space from one reference [`WhitePoint`][details::color::WhitePoint] to
+//! another.
 //!
-//! ### XYZ-RGB conversions
-//! All supported RGB color spaces use the CIE XYZ color space as its reference color space.
-//! Functions in [details::xyz] can be used to create conversion matrices to/from an RGB color space
-//! given a set of primaries and a white point.
+//! Use [`ColorSpace::with_whitepoint()`] to change the `WhitePoint` for a color
+//! space.
 //!
-//! # no_std and glam support
-//! kolor is using by default `std` and `glam`, but both can be disabled separately or together with the
-//! folowing features:
+//! ### XYZ-RGB Conversions
+//!
+//! All supported RGB color spaces use the CIE XYZ color space as its reference
+//! color space. Functions in the [`xyz`](details::xyz) module can be used to
+//! create conversion matrices to/from an RGB color space given a set of
+//! primaries and a white point.
+//!
+//! ## Features
+//!
+//! ### `no_std` & `glam` Support
+//!
+//! By default `kolor` uses `std` and `glam`, but both can be disabled
+//! separately or together with the folowing features:
 //!
 //! | |`std`|`no_std`|
 //! |-|-|-|
 //! |`glam`|`std-glam`|`libm-glam`|
 //! |no `glam`|`std`|`libm`|
 //!
-
+//! ### List of Features
+#![doc = document_features::document_features!()]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(unexpected_cfgs)]
+
+#[cfg(all(feature = "f32", feature = "f64"))]
+compile_error!("Only `f32` or `f64` can be selected at a time.");
 
 #[cfg(feature = "f64")]
-pub type FType = f64;
+pub type Float = f64;
 
 #[cfg(not(feature = "f64"))]
-pub type FType = f32;
+pub type Float = f32;
 
 pub use details::math::{Mat3, Vec3};
 
-/// Create a `Mat3` from a `[FType; 9]`. The order of components is column-major.
+/// Create a `Mat3` from a `[Float; 9]`. The order of components is
+/// column-major.
 #[cfg(not(feature = "glam"))]
 #[macro_export]
 macro_rules! const_mat3 {
@@ -142,8 +174,8 @@ pub mod details {
     pub mod generated_matrices;
     pub mod math;
     #[allow(clippy::excessive_precision)]
-    #[allow(non_snake_case)]
     #[allow(clippy::many_single_char_names)]
+    #[allow(non_snake_case)]
     pub mod transform;
     pub mod xyz;
 }

--- a/matrix-gen/Cargo.toml
+++ b/matrix-gen/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-kolor-64 = { version = "0.1.9", path = "../build/kolor-64", default-features = false, features = [
+kolor-64 = { version = "0.2", path = "../build/kolor-64", default-features = false, features = [
     "std-glam",
-    "f64"
+    "f64",
 ] }

--- a/matrix-gen/src/main.rs
+++ b/matrix-gen/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
     }
     let mut out_str = String::with_capacity(conversions.len() * 256);
     out_str += "use super::{
-    color::{RGBPrimaries, WhitePoint},
+    color::{RgbPrimaries, WhitePoint},
 };
 use crate::Mat3;\n\n";
     let mut const_matches = String::with_capacity(conversions.len() * 128);
@@ -53,7 +53,7 @@ pub const {}_TO_{}: Mat3 = Mat3::from_cols_array(&[
 
         const_matches += &format!(
             "
-        (RGBPrimaries::{:?}, WhitePoint::{:?}, RGBPrimaries::{:?}, WhitePoint::{:?}) => {{
+        (RgbPrimaries::{:?}, WhitePoint::{:?}, RgbPrimaries::{:?}, WhitePoint::{:?}) => {{
             Some({}_TO_{})
         }}",
             src.primaries(),
@@ -68,9 +68,9 @@ pub const {}_TO_{}: Mat3 = Mat3::from_cols_array(&[
     out_str += &format!(
         r#"
 pub fn const_conversion_matrix(
-    src_primaries: RGBPrimaries,
+    src_primaries: RgbPrimaries,
     src_wp: WhitePoint,
-    dst_primaries: RGBPrimaries,
+    dst_primaries: RgbPrimaries,
     dst_wp: WhitePoint,
 ) -> Option<Mat3> {{
     if src_primaries == dst_primaries && src_wp == dst_wp {{


### PR DESCRIPTION
* Made all names conform to [Rust API naming guidelines](https://rust-lang.github.io/api-guidelines/naming.html).
  
   This breaks the API so I bumpled version to `0.2`. I already have fixes/a PR for the `colstodian` crate (which hasn't been updated since 3 years) which is the only noteworthy of the two dependents on `kolor` listed on `crates.io`.

* Fixed docs (grammar, typos, quoting of API refs., etc.).

* Added support for auto-documenting feature flags.

* Improved UX of CAT module.

* Bumped deps (i.e. `glam`) to latest.
